### PR TITLE
feat: Remediation A-E (security, AI extraction, UI dark-mode) + Anthropic Claude provider

### DIFF
--- a/.ai/honest-code-review-2026-05-09.md
+++ b/.ai/honest-code-review-2026-05-09.md
@@ -1,0 +1,243 @@
+# DocFlowHub — Honest Code Review
+
+**Data**: 2026-05-09
+**Branch**: `feature/sprint8-modern-ui-design`
+**Reviewer**: Claude (Opus 4.7)
+**Metoda**: Weryfikacja stanu kodu względem deklaracji w dokumentacji (`prd.md`, `project-status-summary.md`, `current-sprint-status.md`, `CLAUDE.md`).
+
+> **Uwaga**: To review jest świadomie krytyczne. Dokumentacja projektu jest bardzo entuzjastyczna ("100% Complete", "Production Ready", "Beautiful", "Stunning", "Enterprise Grade"). Celem review jest zderzenie tych deklaracji z faktami w kodzie.
+
+## TL;DR
+
+DocFlowHub jest **solidnym MVP/portfolio-projektem** z dobrze przemyślaną architekturą warstwową, działającym CRUD dokumentów, integracją z Azure Blob i OpenAI oraz świeżym, ładnym UI po Sprincie 8. Natomiast **deklaracje "Production Ready / Enterprise Grade" są mocno na wyrost**:
+
+- pokrycie testami jest dramatycznie niskie (~4 pliki testowe na cały system),
+- kluczowe AI features są **częściowo zaślepione** (PDF/DOC/DOCX text extraction zwraca pusty string),
+- brakuje walidacji uploadów (typ/rozmiar/MIME) i obiecanego virus scanningu,
+- kilka stron Razor to monolity 1000–2600 linii z inline `<style>` i `<script>`,
+- dokumentacja ma wewnętrzne sprzeczności (75% vs 100% w tym samym pliku).
+
+To jest **dobry projekt portfolio** — ale jeszcze nie enterprise-grade SaaS.
+
+---
+
+## 1. Test Coverage — 🚨 PROBLEM
+
+**Deklaracja**: "Full test coverage with 100% pass rate (21/21 tests passing)".
+
+**Rzeczywistość**:
+- 4 pliki testowe + 1 helper (`tests/DocFlowHub.Tests/`):
+  - [DocumentServiceTests.cs](tests/DocFlowHub.Tests/Unit/Services/Documents/DocumentServiceTests.cs)
+  - [DocumentMoveTests.cs](tests/DocFlowHub.Tests/Unit/Services/Documents/DocumentMoveTests.cs)
+  - [DocumentStorageServiceTests.cs](tests/DocFlowHub.Tests/Unit/Services/Storage/DocumentStorageServiceTests.cs)
+  - [TeamServiceTests.cs](tests/DocFlowHub.Tests/Unit/Services/Teams/TeamServiceTests.cs)
+  - [TestDataBuilder.cs](tests/DocFlowHub.Tests/Helpers/TestDataBuilder.cs)
+- **Brak testów dla**: AI services (OpenAIService, TextExtractionService, AISettingsService), Admin services (UserManagementService, AnalyticsService, SystemSettingsService), Profile, Projects, Folders, Roles, wszystkich PageModels, autoryzacji, walidacji uploadu.
+- Brak testów integracyjnych (E2E, kontrolerów, Razor Pages).
+- "21/21" to nie znak sukcesu — to znak **bardzo wąskiego scope'u testów**.
+
+**Co naprawić**: Minimum integration tests dla flow upload→summary→download oraz testy autoryzacji na POST handlerach. Bez tego claim "Production Ready" jest fałszywy.
+
+---
+
+## 2. Architektura — ⚠️ CONCERNS
+
+**Deklaracja**: Clean Architecture (Core / Infrastructure / Web).
+
+**Rzeczywistość**:
+- ✅ Podział na 3 projekty istnieje i jest sensowny.
+- ✅ `Core` zawiera modele i interfejsy bez zależności na infrastrukturę.
+- ✅ `ServiceResult<T>` używany konsekwentnie.
+- ⚠️ **PageModele orkiestrują 5–7 serwisów** zamiast korzystać z fasady. Przykład: [Upload.cshtml.cs](src/DocFlowHub.Web/Pages/Documents/Upload.cshtml.cs) (476 linii) wstrzykuje `IDocumentService`, `ICategoryService`, `ITeamService`, `IAISettingsService`, `IDocumentSummaryService`, `IProjectService`, `IFolderService`. To nie Clean Architecture, to **Razor Page jako application service**.
+- ⚠️ Część interfejsów puchnie (np. `IUserManagementService` ma kilkanaście metod) — God interface zaczyna się formować.
+- ⚠️ Brak warstwy *application* / use-case / mediatora. CLAUDE.md twierdzi "Implement MediatR pattern" — w kodzie nie ma MediatR.
+
+---
+
+## 3. Razor Pages — 🚨 PROBLEM
+
+**Deklaracja**: "Modern, professional, glass morphism design".
+
+**Rzeczywistość — rozmiary plików `.cshtml`**:
+| Plik | Linie |
+|---|---|
+| [Pages/Documents/Index.cshtml](src/DocFlowHub.Web/Pages/Documents/Index.cshtml) | **2 653** |
+| [Pages/Index.cshtml](src/DocFlowHub.Web/Pages/Index.cshtml) (dashboard) | **1 741** |
+| [Pages/Documents/Upload.cshtml](src/DocFlowHub.Web/Pages/Documents/Upload.cshtml) | **1 353** |
+| [Pages/Settings/AI.cshtml](src/DocFlowHub.Web/Pages/Settings/AI.cshtml) | **1 115** |
+| [Pages/Projects/Index.cshtml](src/DocFlowHub.Web/Pages/Projects/Index.cshtml) | **1 093** |
+| [Pages/Folders/Details.cshtml](src/DocFlowHub.Web/Pages/Folders/Details.cshtml) | **1 049** |
+| Pages/Projects/Details.cshtml | 999 |
+| Pages/Folders/Index.cshtml | 998 |
+| Pages/Documents/Details.cshtml | 899 |
+
+**To są monolity.** Zdrowa Razor Page powinna mieć <300–400 linii. Inline `<style>` i `<script>` są na porządku dziennym (np. style w `Pages/Documents/Index.cshtml` od linii ~1143, skrypty od ~711).
+
+**Problemy techniczne**:
+- Dublowanie CSS-glass-morphism w wielu plikach zamiast w `wwwroot/css/themes.css`.
+- JavaScript wpisany w Razor zamiast w `.js` z `<script src=…>`.
+- Logika sortowania budowana ręcznie zamiast `Url.Page(…)` / tag helpers (kruche, łatwe do XSS / złamania URL).
+- `HandleAIProcessingAsync` używa fire-and-forget `Task.Run` z `Debug.WriteLine` — to kod debugowy w "production ready" pliku.
+
+**Co naprawić**: Wydzielić sekcje statystyk, filtrów, tabeli, modali do partial views (`_DocumentStatsCard.cshtml`, `_DocumentFilters.cshtml`, `_DocumentTable.cshtml`). Przenieść inline CSS/JS do plików w `wwwroot/`. Cel: każda strona <500 linii.
+
+---
+
+## 4. CSS — ⚠️ CONCERNS
+
+**Rzeczywistość**:
+- 3 pliki CSS w `wwwroot/css/` (`site.css`, `themes.css`, `ux-enhancements.css`) ~792 linii.
+- ✅ Theme system (CSS variables + `data-theme="dark"`) jest sensownie zrobiony.
+- ⚠️ Brak design tokens — kolory/spacing hardkodowane w wielu miejscach.
+- ⚠️ Brak BEM/komponentowego scoping — wszystko w global scope.
+- ⚠️ Glass-morphism efekt powtórzony w kilku miejscach zamiast jednej klasy `.glass-card`.
+- ⚠️ Inline `<style>` w `.cshtml` pomija ten cały system — efekt: zmiana koloru wymaga edycji w N miejscach.
+
+---
+
+## 5. Bezpieczeństwo — 🚨 PROBLEM
+
+### 5.1 Sekrety w repo
+- ✅ `appsettings.json`, `appsettings.Development.json`, `appsettings.Production.json` są **w `.gitignore`** — secrets nie są w repo.
+- ✅ Klucz OpenAI ładowany z `IConfiguration` w [OpenAIService.cs](src/DocFlowHub.Infrastructure/Services/AI/OpenAIService.cs).
+- 🚨 **`.ai/openai-key.md` zawiera prawdziwy-wyglądający klucz OpenAI w working directory.** Plik jest w `.gitignore` (`*-key*`), więc nie został scommitowany — ale:
+  - to ryzyko przy `git add -A`,
+  - klucz powinien być **odwołany i zrotowany** (lepiej zakładać, że wyciekł, niż się modlić),
+  - docelowo: User Secrets / Azure Key Vault, nie plik tekstowy obok kodu.
+
+### 5.2 Walidacja uploadów
+- 🚨 W [Upload.cshtml.cs](src/DocFlowHub.Web/Pages/Documents/Upload.cshtml.cs) brakuje wyraźnej walidacji:
+  - whitelisty rozszerzeń,
+  - twardego limitu rozmiaru,
+  - sniffingu MIME / magic bytes.
+- 🚨 PRD ([prd.md:118](.ai/prd.md#L118)) wspomina "virus scanning hook in storage service design" — **w kodzie nie ma żadnego hooka antywirusowego**. To pure-fiction w PRD.
+
+### 5.3 CSRF
+- ⚠️ Nie ma jawnego `[ValidateAntiForgeryToken]` ani `AutoValidateAntiforgeryToken` — ale **Razor Pages od ASP.NET Core 2.0 włącza walidację antiforgery domyślnie dla POST/PUT/DELETE/PATCH**, więc to nie jest dziura jak w klasycznym MVC. **Nie panikuj**, ale dla świadomego czytelnika dodanie globalnego `services.AddAntiforgery(...)` z jawną konfiguracją SameSite/Secure jest wartością.
+
+### 5.4 Inne
+- ⚠️ `AISettings.CustomApiKey` (jeśli pole istnieje w DB) — sprawdzić czy szyfrowane at rest. Klucze użytkownika w plain text to data-leak waiting to happen.
+- ⚠️ Brak rate limitingu na endpointach AI / upload — łatwy DoS przy public deploymencie.
+
+---
+
+## 6. Integracja AI — ⚠️ CONCERNS
+
+[OpenAIService.cs](src/DocFlowHub.Infrastructure/Services/AI/OpenAIService.cs):
+- ✅ Klucz z `IConfiguration`, logging, try/catch.
+- ⚠️ Brak retry/exponential backoff (network glitch = błąd dla użytkownika).
+- ⚠️ Brak per-user rate limiting / kwoty (claim "cost optimization" w docs słabo poparty).
+- ⚠️ Generic catch-all gubi szczegóły wyjątków.
+
+[TextExtractionService.cs](src/DocFlowHub.Infrastructure/Services/AI/TextExtractionService.cs) — **najpoważniejszy problem AI**:
+- 🚨 Linia ~209: `TODO: Consider using a markdown parser`.
+- 🚨 Linia ~220: `TODO: Implement PDF text extraction` — **PDF zwraca pusty string**.
+- 🚨 Linia ~244: `TODO: Implement DOC text extraction` — **DOC zwraca pusty string**.
+- 🚨 Linia ~266: `TODO: Implement DOCX text extraction` — **DOCX zwraca pusty string**.
+
+**Konsekwencja**: AI summarization na PDF/DOC/DOCX (czyli ~80% realnych dokumentów biurowych) **nie działa albo halucynuje na pustym stringu**. PRD i PRD-podobne dokumenty mówią o "AI Document Summarization — COMPLETE & PRODUCTION READY" — to **nieprawda**.
+
+**Co zrobić**: Dodać `PdfPig` (PDF) i `DocumentFormat.OpenXml` (DOCX). DOC (binarny .doc, stary format) — albo wymusić konwersję, albo użyć płatnego SDK.
+
+---
+
+## 7. EF Core / Data Layer — ⚠️ CONCERNS
+
+- 🚨 **Tylko 1 migracja** w [Infrastructure/Data/Migrations/](src/DocFlowHub.Infrastructure/Data/Migrations/): `20250721185704_MakeUserCommunicationAdminIdNullable.cs`. Dla projektu z 8 sprintami i ewolucją modelu (Documents, Versions, Categories, Teams, Projects, Folders, AI, Analytics, Settings) — to bardzo dziwne. Możliwe wyjaśnienia:
+  - migracje były squash-owane do snapshotu (ale wtedy snapshot też powinien być widoczny w historii),
+  - schema jest zarządzana inaczej (DB-first?),
+  - **migracje były usuwane i regenerowane** — to anti-pattern, bo niszczy ścieżkę upgrade dla istniejących wdrożeń.
+- ✅ Soft delete zaimplementowane: `IsDeleted` na `Document` + `HasQueryFilter(d => !d.IsDeleted)` w `DocumentConfiguration`.
+- ⚠️ Potencjalne N+1 w listach z `.Include` — wymaga punktowego sprawdzenia z profilerem.
+
+**Co zrobić**: Wyjaśnić strategię migracji w README. Jeśli to projekt portfolio, jedna konsolidowana migracja jest OK — ale wtedy nie wprowadzaj w docsach narracji "ewolucja przez 8 sprintów".
+
+---
+
+## 8. TODO / FIXME / Debug logs — ⚠️ CONCERNS
+
+Konkretne (ignorując vendor JS):
+- `TextExtractionService.cs` — 4× TODO (PDF, DOC, DOCX, markdown parser) → pkt 6.
+- `ProjectService.cs` — TODO: "Implement when team sharing is added".
+- `DocumentService.cs` (linia ~858, ~874) — TODO: team sharing validation.
+- `Admin/Users/Edit.cshtml.cs` — TODO: password change notification email.
+- `Admin/Users/Create.cshtml.cs` — TODO: welcome email functionality.
+- `Admin/Users/Details.cshtml` — 3× TODO.
+- `Upload.cshtml.cs` — `System.Diagnostics.Debug.WriteLine` w handlerze AI (powinien być `ILogger`).
+- `Pages/Documents/Index_CardLayout_Backup.cshtml` — backup file zostawiony w repo, nie powinien być versionowany.
+
+**Wniosek**: Notification engine, team-sharing validation i AI text extraction są **nieukończone**, mimo że dokumenty mówią "Sprint 9 jako kolejny krok". Te kawałki to długi techniczny wewnątrz "ukończonych" sprintów.
+
+---
+
+## 9. Stan repo (uncommitted work) — ⚠️ CONCERNS
+
+`git status` pokazuje **20 zmodyfikowanych plików nieczommitowanych**:
+- 14× `.cshtml` w `Pages/` (Account/Manage, Admin/Settings, Folders, Projects, Teams, Settings/AI, Shared/_Layout)
+- 5× plików w `.ai/` (status summaries, sprint8 logs)
+
+To wygląda na **kolejną iterację po commicie `46802b0 feat: Complete Sprint 8 Phase 8.5`** — być może następna sesja nad UI, którą ktoś zostawił otwartą. **Decyzja do podjęcia**: commit, stash, czy reset. Bez tego review pracuje na ruchomym celu.
+
+---
+
+## 10. Niespójności w dokumentacji — ⚠️ CONCERNS
+
+Sama dokumentacja jest niespójna i zmniejsza zaufanie do statusów:
+
+| Plik | Mówi | Sprzeczność |
+|---|---|---|
+| [current-sprint-status.md:6](.ai/sprints/current-sprint-status.md#L6) | "Sprint 8 — 100% COMPLETE" | …w tym samym pliku linia 13: "75% Complete" |
+| [CLAUDE.md:4](.cursor/claude-rules/CLAUDE.md#L4) | "75% completion" | Reszta docsów: "100% complete" |
+| [next-step-detailed-plan.md:9](.ai/next-step-detailed-plan.md#L9) | "Continuing Phase 8.4: Main Dashboard Modernization" | Nieaktualne — Phase 8.4 ma być skończona |
+| [technology-stack.md:17](.ai/technology-stack.md#L17) | "ASP.NET Core 8 + EF Core 8" | Faktycznie projekt to **ASP.NET Core 9** |
+| [implementation-plan.md:108](.ai/implementation-plan.md#L108) | "✅ COMPLETED (Sprints 1-7)" | OK — ale [linia 84-91](.ai/implementation-plan.md#L84-L91) Sprint 8 też 100% — spójne |
+
+**Konsekwencja**: Dla nowego dewelopera, który spróbuje się zorientować po samych docsach, dokumentacja jest niewiarygodna. **Status powinien być w jednym miejscu**, nie w sześciu.
+
+---
+
+## Top 7 issues — kolejność priorytetów
+
+1. **🚨 [SECURITY] Zrotuj klucz OpenAI**, który jest w `.ai/openai-key.md`. Nawet jeśli `.gitignore` go chroni, zakładaj, że wyciekł (mogłeś wkleić w screenshot, w issue, w czat). Przenieś klucz do User Secrets (`dotnet user-secrets set OpenAI:ApiKey ...`) lub Azure Key Vault. Skasuj plik.
+2. **🚨 [AI] Zaimplementuj PDF/DOCX text extraction** (PdfPig + OpenXML). Bez tego "AI summarization" jest pustym claimem dla większości realnych dokumentów.
+3. **🚨 [SECURITY] Walidacja uploadów**: whitelist rozszerzeń, max size, MIME sniffing. Albo (preferowane) ClamAV/Azure Defender skan przed zapisem do bloba.
+4. **🚨 [TESTS] Rozbuduj testy** — minimum: integration test upload→summary→download, testy autoryzacji POST handlerów, testy fallbacku przy błędach OpenAI. "21 testów" to nie jest argument za "production ready".
+5. **⚠️ [REFACTOR] Rozbij monolity Razor**. Zacznij od `Documents/Index.cshtml` (2 653 linii) — wydziel `_StatsCard.cshtml`, `_FilterPanel.cshtml`, `_DocumentTable.cshtml`, `_BulkActions.cshtml`. Inline CSS/JS → `wwwroot/css/documents.css` i `wwwroot/js/documents-page.js`.
+6. **⚠️ [DOCS] Pojedyncze źródło prawdy o statusie projektu**. Zostaw albo `project-status-summary.md`, albo `current-sprint-status.md`. Zaktualizuj `technology-stack.md` (ASP.NET 9, nie 8). Usuń `*-Roadmap.md` jeśli nieaktualny.
+7. **⚠️ [REPO HYGIENE]** Skasuj `Pages/Documents/Index_CardLayout_Backup.cshtml`. Zdecyduj, co zrobić z 20 niescommitowanymi plikami. Dodaj `*.bak`, `*_Backup.*` do `.gitignore`.
+
+---
+
+## Co działa dobrze ✅
+
+Żeby review nie był jednostronnie krytyczny — projekt ma realne mocne strony:
+
+- **Przyzwoity podział warstw** (Core/Infrastructure/Web), nawet jeśli czasem przecieka.
+- **Typed configuration + DI** — `IConfiguration`, `services.AddInfrastructure()`, scope'y w porządku.
+- **Soft delete + query filters** — zaimplementowane porządnie.
+- **Theme system z CSS variables** — dobry kierunek architektoniczny.
+- **ServiceResult<T>** używane konsekwentnie zamiast wyjątków na ścieżkach biznesowych.
+- **Identity + role-based authorization** — solidna podstawa.
+- **GitHub Actions CI** — istnieje pipeline buildu.
+- **Realne user-facing features**: upload + versioning + AI summary + version comparison + projects/folders/teams + admin panel + analytics — to jest sporo na portfolio-projekt.
+
+---
+
+## Werdykt końcowy
+
+**DocFlowHub jest świetnym projektem portfolio** — pokazuje, że autor potrafi zaprojektować warstwową aplikację .NET, zintegrować Azure Blob, OpenAI i ASP.NET Identity, dowieźć rozsądny UI z theming. To **mocne MVP**.
+
+**Nie jest natomiast tym, co claim'ują docsy** — "Production Ready Enterprise Platform" wymagałoby:
+- 60–80% test coverage (nie 4 pliki),
+- działającego AI extraction dla głównych formatów (nie stuby),
+- security hardeningu uploadów + AV,
+- rotacji secretów + Key Vault,
+- migration history zamiast 1 pliku,
+- monitoringu (Application Insights / OTEL),
+- rate limiting + cost controls.
+
+**Sugestia**: Zaktualizuj narrację. "Solidne portfolio + MVP" to silna sprzedaż. "Production Ready Enterprise Grade" przy realnym audycie się rozsypie i podważy wiarygodność reszty rzeczy w docs.
+
+---
+
+*Review wygenerowane przez Claude (Opus 4.7) na bazie statycznej analizy repo + dokumentacji. Nie zastępuje pełnego pentestu ani audytu wydajnościowego.*

--- a/.ai/project-status-summary.md
+++ b/.ai/project-status-summary.md
@@ -4,7 +4,15 @@
 **Current Sprint**: Sprint 8 - **Modern UI/UX Design System** 🎉 **COMPLETE**  
 **Major Achievement**: ✅ **ALL PHASES COMPLETE** - Full Visual Transformation Achieved  
 **Next Focus**: 🎯 **Sprint 9: Advanced Enterprise Features**  
-**Project Status**: **Enterprise Platform with Beautiful Modern Design** - Production Ready
+**Project Status**: Strong MVP / portfolio platform — modern UI on most pages, with known gaps (see below)
+
+> ⚠️ **Verified status note (2026-07-02)**: The "100% complete / all pages modernized /
+> production-ready enterprise" language below is aspirational and does not match the code.
+> A direct source audit found: AI text extraction for PDF/DOC/DOCX is stubbed, ~20 pages
+> are still un-modernized (mostly forms + deep admin), test coverage is 4 files, and the
+> OpenAI key sits in `.ai/openai-key.md`. The accurate backlog and page-by-page audit live
+> in [`remediation-plan.md`](remediation-plan.md). Treat that file as the source of truth
+> for status; the sections below are historical sprint notes.
 
 ## 🎉 **SPRINT 8 - DESIGN TRANSFORMATION: 100% COMPLETE!** ✅
 

--- a/.ai/remediation-plan.md
+++ b/.ai/remediation-plan.md
@@ -104,6 +104,26 @@ flagged test items — **E1** (inject a chat-client seam into `OpenAIService`) a
 
 ---
 
+**2026-07-03 — G: Anthropic Claude provider added (user request, post-remediation):**
+- **Multi-provider AI**: added the official `Anthropic` C# SDK (12.35.1) and `ClaudeAIService`
+  implementing the existing `IAIService`. New `AIServiceRouter` registered as `IAIService`
+  dispatches per requested model ("claude-*" → Anthropic, otherwise OpenAI; null → default
+  provider). Providers resolve lazily — a missing API key for the unused provider surfaces as a
+  clean failed `AIResponse`, never a startup crash.
+- **Models are user-selectable everywhere** (Upload, Settings/AI, Details comparison): `AIModel`
+  enum gained `ClaudeHaiku45`, `ClaudeSonnet5`, `ClaudeOpus48` — APPENDED (PreferredModel is
+  persisted as int; positions pinned by a unit test). **Default model is now Claude Haiku 4.5**
+  (`AIModelHelper.GetDefaultModel()`, used by all former hardcoded `Gpt4oMini` defaults —
+  7 call sites centralized). String→enum parsing centralized in `AIModelHelper.FromApiString`.
+- Config: `Anthropic:Model` (claude-haiku-4-5) + `Anthropic:MaxTokens` in appsettings.json;
+  **`Anthropic:ApiKey` must be set via user-secrets** (`dotnet user-secrets set "Anthropic:ApiKey"
+  "<KEY>" --project src/DocFlowHub.Web`). Claude SDK auto-retries 429/5xx (no hand-rolled retry).
+- Cost/time/capability UI maps (Upload + Details JS and page models) extended with Claude entries.
+- Tests: `AIModelHelperTests` (24 cases — enum pinning, round-trips, provider routing, defaults).
+  **Full suite: 69/69 passing.** Not yet exercised against the live Anthropic API (needs a key).
+
+---
+
 ## Verified findings (2026-07-02)
 
 - **AI text extraction is stubbed** — `TextExtractionService.cs` still has `TODO: Implement`

--- a/.ai/remediation-plan.md
+++ b/.ai/remediation-plan.md
@@ -124,6 +124,35 @@ flagged test items — **E1** (inject a chat-client seam into `OpenAIService`) a
 
 ---
 
+**2026-07-03 — PR #52 code-review fixes (all 8 findings + 2 polish items):**
+Review found the Claude enum was appended but several `AIModel`/model-string switches in
+files outside the original diff were never extended — making the *new default provider* the
+one those paths mishandled. Fixed:
+- **F1** `AIServiceRouter` health/connectivity now probes whichever provider(s) are actually
+  configured (key present), not just the default — an OpenAI-only deploy no longer reports a
+  valid key as invalid.
+- **F2** `AIUsageTrackingService`: Claude models added to `ModelCosts`; `ParseModelString`
+  now delegates to `AIModelHelper.FromApiString` (no more Claude-costed-as-gpt-4o-mini).
+- **F3** `FileSignatureValidator` accepts UTF-16/UTF-32/UTF-8 BOM text (was rejecting valid
+  Unicode `.txt`/`.md` on NUL bytes — regression that disagreed with the extractor).
+- **F4** `AISettingsService` cost-level/max-tokens gained Claude arms (recommended Haiku no
+  longer displays worse specs than GPT).
+- **F5** `Details.cshtml.cs` preferred-model + comparison switches → `ToApiString`/`ToDisplayName`
+  (UI no longer shows `gpt-4o-mini` for Claude users).
+- **F6** 🔴 `ProfileService.UpdateProfilePictureAsync` had **no validation at all** — added image
+  extension whitelist + 5 MB cap + magic-byte check (closes a stored-XSS vector: `.html`/`.svg`
+  renamed to `.png` served from the site origin).
+- **F7** Provider services registered as singletons (pool the `AnthropicClient`/`HttpClient`
+  instead of rebuilding per request).
+- **F8** Removed the hand-rolled OpenAI retry (SDK already retries; the manual loop compounded
+  to up to 9 calls and inflated the health probe).
+- Polish: hoisted duplicated `.section-heading`/`.parent-picker` CSS into `components.css`
+  (removed from 5 pages); added a "re-save .doc as .docx for AI summaries" hint on Upload.
+- Tests: +6 (Unicode-BOM cases + a switch-coverage guard so this bug class can't regress).
+  Full suite **75/75 passing**, build 0 errors.
+
+---
+
 ## Verified findings (2026-07-02)
 
 - **AI text extraction is stubbed** — `TextExtractionService.cs` still has `TODO: Implement`

--- a/.ai/remediation-plan.md
+++ b/.ai/remediation-plan.md
@@ -93,6 +93,17 @@ page-by-page UI modernization audit.
 
 ---
 
+**2026-07-03 — committed.** Work landed on `feature/sprint8-modern-ui-design` as five focused
+commits: `chore(A)` hygiene+docs, `feat(B)` magic-byte upload validation, `feat(C)` PDF/DOCX
+extraction+retry, `feat(D)` UI modernization, `test(E)` validation+extraction tests. The LF/CRLF
+churn resolved itself once `.gitattributes` was committed (working tree now clean except local
+`.claude/settings.local.json`, intentionally untracked). Full build 0 errors, 45/45 tests green.
+Still open: **key rotation (B1, user)**, **visual light/dark pass (needs the app)**, and the two
+flagged test items — **E1** (inject a chat-client seam into `OpenAIService`) and **E2**
+(`WebApplicationFactory` harness for authorization tests).
+
+---
+
 ## Verified findings (2026-07-02)
 
 - **AI text extraction is stubbed** — `TextExtractionService.cs` still has `TODO: Implement`

--- a/.ai/remediation-plan.md
+++ b/.ai/remediation-plan.md
@@ -1,0 +1,170 @@
+# DocFlowHub — Remediation Plan
+
+**Created**: 2026-07-02
+**Branch**: `feature/sprint8-modern-ui-design`
+**Basis**: Verified against current code (not status docs). Cross-checks the honest
+code review (`honest-code-review-2026-05-09.md`) against today's source and adds a
+page-by-page UI modernization audit.
+
+> Status docs claim "100% complete / all pages modernized / production ready".
+> Direct code inspection shows this is not accurate. This plan is the real backlog
+> to close the gap between the claims and the code.
+
+---
+
+## Progress log
+
+**2026-07-02 — Workstreams A, B, C implemented (not yet committed):**
+- **A done.** Added `.gitattributes` (fixes the LF/CRLF churn — the "20 modified files"
+  were EOL-only noise, zero content change). Backup cshtml was already gitignored (never in
+  repo) — deleted the disk copy. Fixed `.NET 8→9` in `technology-stack.md`; reconciled the
+  75%/100% contradiction; added verified-status banners pointing here. `.claude/settings.local.json`
+  is tracked — flagged for untracking (user's call). Run `git add --renormalize .` before committing.
+- **B done (code).** Upload validation already had size + extension whitelist in
+  `DocumentStorageService`; added `FileSignatureValidator` (magic-byte content sniffing) so a
+  renamed file can't bypass the whitelist. B1 secret handling was already config-based +
+  user-secrets wired — **rotation is a pending USER action**; `.ai/openai-key.md` to be deleted after.
+  B3 (rate limiting, `CustomApiKey` encryption) deferred.
+- **C mostly done.** PDF via **PdfPig**, DOCX via **DocumentFormat.OpenXml** — both implemented,
+  return empty on failure (no more garbage fed to the summarizer). Retry/backoff added to
+  `OpenAIService`. **Legacy binary .doc: no maintained OSS extractor exists** (NPOI ships no
+  HWPF) — currently degrades gracefully (logs + returns empty). DECISION PENDING: accept the
+  limitation, or add a commercial/limited lib (Aspose paid / Spire.Doc.Free watermark).
+- Full solution builds clean (0 errors). Extraction **verified at runtime**: added
+  `TextExtractionServiceTests` (real DOCX round-trip + real minimal PDF + legacy-.doc
+  degradation). Full suite green: **27/27 passing** (was 23 + 4 new). Legacy .doc decision:
+  **accept the limitation** (graceful degradation, no paid lib).
+- **D in progress.** Created shared `wwwroot/css/components.css` (theme-aware page-header /
+  form / card / button system) and wired it into `_Layout` before the Styles section (zero
+  regression risk to the 17 already-modernized pages; admin pages inherit it). Modernized the
+  **6 CRUD forms**: Projects/Create+Edit, Teams/Create+Edit, Folders/Create+Edit — old Bootstrap
+  `card` + hardcoded `#f8f9fa` (dark-mode-broken) → tokenized modern components. Web builds clean.
+  REMAINING in D: Document pages (Upload, Details, Edit) and Admin area (Analytics, UserLimits,
+  Roles ×5, Users ×4) — ~14 pages. Not yet visually verified (needs the app running).
+
+**2026-07-03 — D continued: Document pages done (not yet committed):**
+- Modernized the **3 Document pages** (Upload, Details, Edit): `container`/`container-fluid` +
+  `card-header bg-primary/bg-success text-white` shells → `page-container`/`page-header`/
+  `form-card`/`content-card`; modern breadcrumbs. Tokenized every dark-mode-breaking hardcoded
+  color: Upload's `<style>` block (`#dee2e6`/`#f8f9fa`/`#6c757d`/`#0d6efd`/`#198754`/`#fafafa`/
+  `#e3f2fd` → `var(--border-color)`/`--surface-secondary`/`--text-secondary`/`--accent-color`/
+  `--success-color`), Details' `bg-light` panels → `.token-panel`, `.list-group-item-primary`
+  hardcoded rgba → tokens. All form fields, IDs, and the ~700-line Upload JS preserved verbatim.
+  Web builds clean (0 errors); div balance verified (Upload 82/82, Edit 33/33, Details 106/106).
+  REMAINING in D: Admin area only — Analytics, UserLimits, Roles ×5, Users ×4 (~11 pages).
+
+**2026-07-03 — D complete: Admin area theme-corrected (not yet committed):**
+- All 11 deep admin pages share `_AdminLayout` (which sits under `_Layout`, so `components.css`
+  and the token system are already available). Their only real defect was **dark-mode breakage**:
+  raw Bootstrap `.card`/`.table`/`.form-control`/`.list-group-item` default to white.
+- **DRY fix, not 11 rewrites:** added a theme-aware override block to `_AdminLayout.cshtml` that
+  swaps white → design tokens for every legacy component at once. Light mode is unchanged (tokens
+  resolve to the same near-white values); dark mode is fixed everywhere in one place. Added targeted
+  overrides for `bg-light` PANELS (`.card.bg-light`, `.card-header.bg-light`, `.form-control-plaintext.bg-light`)
+  while deliberately leaving `bg-light` badges alone (they must stay light for their dark text).
+- Page-specific cleanups: Analytics + UserLimits headers → modern `.admin-deep-header`; Users/Details
+  role chip and Users/Index `.bulk-actions-panel`/`.filter-panel` hardcoded `#fff`/`#f8f9fa`/`#dee2e6`
+  → tokens. `card-header bg-primary/bg-success` accents on Roles/Users forms kept (solid accents read
+  fine in both themes; their card bodies are now themed).
+- Web builds clean (0 errors); scan confirms **no remaining hardcoded white backgrounds** in Admin.
+- **Workstream D is now functionally complete** (all pages theme-aware). Still not visually verified
+  in a running app — recommend a light/dark pass before committing. F (monolith refactor) remains optional.
+
+---
+
+**2026-07-03 — E: security + extraction tests added (not yet committed):**
+- **E3 done (the achievable, high-value part):** added `FileSignatureValidatorTests` — 17 pure,
+  dependency-free cases covering the B2 magic-byte check: valid signatures for every accepted format
+  (pdf/png/jpg/jpeg/gif/docx/doc), the core attacks (text→.pdf, exe→.png, gif→.png), text/NUL-byte
+  handling for .txt/.md, empty files, case-insensitive extensions, docx alternate ZIP marker, and the
+  "defer to whitelist for unknown signatures" contract. Plus one **wiring** test in the storage suite
+  (`UploadDocument_WithExtensionSpoofedContent_ShouldFail`) proving the validator is actually invoked
+  inside `UploadDocumentAsync`. Extraction (C) already has `TextExtractionServiceTests`.
+  **Full suite: 45/45 passing** (was 27).
+- **E1 (upload→summarize→download) partial:** upload↔download round-trip is already covered
+  (`UploadAndDownload_ShouldReturnSameContent`). The **summarize** leg can't be tested end-to-end here:
+  `OpenAIService` news up its `ChatClient` internally, so there's no seam to mock the AI call, and a
+  live key isn't available to tests. Closing E1 needs a small refactor to inject the chat client (or an
+  `IChatCompletion` seam) — flagged, not done.
+- **E2 (authorization on Razor POST handlers) blocked on harness:** the test project references only
+  Core + Infrastructure (no Web, no `Microsoft.AspNetCore.Mvc.Testing`). Proper handler/authorization
+  tests need a `WebApplicationFactory` host — a deliberate harness expansion (new package + Web ref).
+  Flagged as a decision, not silently skipped.
+
+---
+
+## Verified findings (2026-07-02)
+
+- **AI text extraction is stubbed** — `TextExtractionService.cs` still has `TODO: Implement`
+  for PDF (L220), DOC (L244), DOCX (L266). It returns placeholder strings / raw-byte
+  "fallback", so AI summaries for PDF/DOC/DOCX are meaningless or hallucinated.
+- **Tests are minimal** — exactly 4 test files (Documents×2, Storage, Teams). No AI,
+  admin, auth, upload-validation, or Razor-page tests.
+- **Single migration** — one migration file for an 8-sprint project (history squashed).
+- **OpenAI key on disk** — `.ai/openai-key.md` holds a real-looking key (gitignored, but treat as leaked).
+- **UI modernization incomplete** — ~20 pages still on old Bootstrap (see map below).
+- **Docs contradict themselves** — "75%" and "100%" in the same file; `technology-stack.md` says .NET 8 (actually 9).
+
+---
+
+## UI modernization audit
+
+### Modernized — Sprint 8 design applied (17)
+Login, Register, Landing (Index/anon), Dashboard (Index), Documents/Index,
+Projects/Index, Projects/Details, Folders/Index, Folders/Details, Teams/Index,
+Teams/Details, Admin/Index, Admin/Settings/Index, Account/Manage/{Index, EditProfile,
+ChangePassword, UploadProfilePicture}, Settings/AI.
+
+### NOT modernized — status after remediation (all now addressed ✅)
+| Group | Pages | Status |
+|---|---|---|
+| Document forms | Documents/Upload, Details, Edit | ✅ Modernized (page-container/form-card/content-card, tokenized styles) |
+| CRUD forms | Projects/Create+Edit, Folders/Create+Edit, Teams/Create+Edit | ✅ Modernized (shared components.css) |
+| Admin deep | Analytics, UserLimits | ✅ Theme-corrected + modern headers |
+| Admin Roles | Index, Create, Edit, Delete, Details | ✅ Theme-corrected via `_AdminLayout` override |
+| Admin Users | Index, Create, Edit, Details | ✅ Theme-corrected via `_AdminLayout` override |
+
+**Original pattern**: listing/hub pages were modernized; nearly every form/create/edit page and
+the deep admin area were skipped. **Now closed** — every page is theme-aware in light + dark.
+Remaining: visual verification in a running app, and optional F (monolith split).
+
+---
+
+## Workstreams
+
+### A — Repo hygiene & docs truth  *(~0.5 day, do first)*
+- **A1** Resolve the ~20 uncommitted Sprint 8 files (commit or stash) — stop working on a moving target.
+- **A2** Delete `Documents/Index_CardLayout_Backup.cshtml`; add `*_Backup.*`, `*.bak` to `.gitignore`.
+- **A3** Collapse status docs to one source of truth; fix 75%-vs-100%; correct `technology-stack.md` to .NET 9.
+- **A4** Rewrite "Production Ready Enterprise" framing → "strong MVP / portfolio".
+
+### B — Security  *(~1–1.5 days, highest real risk)*
+- **B1** 🔴 Rotate OpenAI key in `.ai/openai-key.md`; move to `dotnet user-secrets` / Key Vault; delete the file.
+- **B2** Upload validation — extension whitelist + hard size cap + MIME/magic-byte sniffing in `Upload.cshtml.cs`.
+- **B3** (optional) Rate limiting on AI/upload endpoints; verify `AISettings.CustomApiKey` not stored plaintext.
+
+### C — Make AI actually work  *(~2–3 days, biggest functional gap)*
+- **C1** 🔴 DOCX extraction via `DocumentFormat.OpenXml`.
+- **C2** 🔴 PDF extraction via `PdfPig`.
+- **C3** Legacy DOC — force-convert or explicitly mark unsupported; stop feeding garbage bytes to OpenAI.
+- **C4** Retry/backoff in `OpenAIService`; remove placeholder-string returns.
+
+### D — Finish UI modernization  *(~3–5 days, the gap above)*
+- **D1** Extract repeated glass-morphism/`page-header` patterns into shared partials + `wwwroot/css` classes FIRST.
+- **D2** Document forms: Upload, Details, Edit.
+- **D3** CRUD forms: Projects, Folders, Teams (Create/Edit) — one shared form pattern.
+- **D4** Admin deep pages: Analytics, UserLimits, Roles (5), Users (4).
+
+### E — Tests  *(~2–3 days)*
+- **E1** Integration test: upload → summarize → download.
+- **E2** Authorization tests on POST handlers (owner/admin enforcement).
+- **E3** Unit tests for new extraction (C) and upload validation (B2).
+
+### F — Refactor monoliths  *(optional, folds into D)*
+- Break up `Documents/Index.cshtml` (~2,650 lines) and peers into partials; move inline CSS/JS to `wwwroot/`.
+
+---
+
+## Recommended sequence
+A → B → C → D → E  (F folded into D). A/B are quick and high-value; C fixes the core
+feature; D is the largest but lowest-risk; E can partly run in parallel.

--- a/.ai/sprints/current-sprint-status.md
+++ b/.ai/sprints/current-sprint-status.md
@@ -1,17 +1,23 @@
 # Current Sprint Status - DocFlowHub Project
 
+> ⚠️ **Verified status note (2026-07-02)**: This file previously claimed "100% COMPLETE /
+> ALL PAGES MODERNIZED" in the header while stating "75% Complete" a few lines down — a
+> contradiction. A direct audit found UI modernization is **partial**: listing/hub pages are
+> done, but ~20 form and deep-admin pages are still on old Bootstrap. See
+> [`remediation-plan.md`](../remediation-plan.md) for the verified page-by-page audit and backlog.
+
 ## 📊 PROJECT OVERVIEW
-**Current Sprint**: Sprint 8 (Modern UI/UX Design System) - **100% COMPLETE** 🎉
-**Current Phase**: 🎉 **ALL PHASES COMPLETE** | 🚀 **Sprint 8 Finished!**
-**Project Phase**: Enterprise Platform Design Transformation - **ALL PAGES MODERNIZED** ✨
-**Sprint 8 Progress**: **100% Complete** | **SPRINT 8 COMPLETE**
-**Current Status**: **READY FOR SPRINT 9** | **All UI Modernization Complete**
+**Current Sprint**: Sprint 8 (Modern UI/UX Design System) - **UI modernization ~65% (listing pages done, forms + deep admin pending)**
+**Current Phase**: Listing/hub pages modernized; form pages & deep admin area outstanding
+**Project Phase**: Design transformation in progress — see remediation plan Workstream D
+**Sprint 8 Progress**: Partial — hub pages complete, ~20 pages remaining
+**Current Status**: Remediation plan active (Workstream A → E)
 
 ## 🎉 **SPRINT 8: MODERN UI/UX DESIGN SYSTEM - MAJOR PROGRESS!** ✅
 
 ### 🎯 **Sprint 8 Scope: Complete Design Transformation**
 **Goal**: Transform DocFlowHub into a modern, professional platform with beautiful light/dark theme system
-**Progress**: **75% Complete** - Stunning visual transformation achieved!
+**Progress**: **Partial** - Listing/hub pages modernized; forms and deep admin pages still on old Bootstrap (see remediation plan Workstream D)
 **Priority**: High-impact visual enhancement for enterprise appeal - **Foundation Complete**
 
 #### **✅ Phase 8.1: Authentication & Landing Pages** - **COMPLETE** 🎉

--- a/.ai/technology-stack.md
+++ b/.ai/technology-stack.md
@@ -14,8 +14,8 @@
 
 ## 2. Backend
 
-### ASP.NET Core 8 MVC + Entity Framework Core 8
-- **ASP.NET Core 8** z prostą architekturą:
+### ASP.NET Core 9 + Entity Framework Core 9
+- **ASP.NET Core 9** z prostą architekturą:
   - Kontrolery i widoki (MVC)
   - Podstawowe serwisy dla logiki biznesowej
   - Repozytoria dla dostępu do danych (opcjonalnie)
@@ -24,7 +24,7 @@
   - Bezpośrednie używanie ViewModeli
   - Podstawowe metody konwersji między modelami
 
-- **Entity Framework Core 8** z code-first approach
+- **Entity Framework Core 9** z code-first approach
 - **SQL Server Express LocalDB** (dla developmentu)
 - **ASP.NET Core Identity** do zarządzania użytkownikami i uprawnieniami
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,36 @@
+# Normalize line endings: store LF in the repo, check out native on each platform.
+# This stops the constant LF<->CRLF churn that made ~20 files show as "modified"
+# with no real content change. After adding this file, run once:
+#   git add --renormalize .
+* text=auto
+
+# Source / text
+*.cs      text diff=csharp
+*.cshtml  text
+*.razor   text
+*.csproj  text
+*.sln     text
+*.props   text
+*.targets text
+*.json    text
+*.md      text
+*.css     text
+*.js      text
+*.html    text
+*.xml     text
+*.config  text
+*.yml     text
+*.yaml    text
+
+# Binary (never touch line endings)
+*.png  binary
+*.jpg  binary
+*.jpeg binary
+*.gif  binary
+*.ico  binary
+*.svg  text
+*.pdf  binary
+*.doc  binary
+*.docx binary
+*.zip  binary
+*.dll  binary

--- a/src/DocFlowHub.Core/Models/AI/AIModels.cs
+++ b/src/DocFlowHub.Core/Models/AI/AIModels.cs
@@ -1,29 +1,55 @@
 namespace DocFlowHub.Core.Models.AI;
 
 /// <summary>
-/// Available AI models for document processing
+/// AI providers supported by the application
+/// </summary>
+public enum AIProvider
+{
+    OpenAI,
+    Anthropic
+}
+
+/// <summary>
+/// Available AI models for document processing.
+/// IMPORTANT: PreferredModel is persisted as an int (see AISettingsConfiguration) —
+/// only APPEND new values, never reorder or remove existing ones.
 /// </summary>
 public enum AIModel
 {
     /// <summary>
-    /// GPT-4.1 - Most capable model
+    /// GPT-4.1 - Most capable OpenAI model
     /// </summary>
     Gpt41,
-    
+
     /// <summary>
     /// GPT-4.1 Mini - Fast and efficient version
     /// </summary>
     Gpt41Mini,
-    
+
     /// <summary>
     /// GPT-4o - Advanced model
     /// </summary>
     Gpt4o,
-    
+
     /// <summary>
     /// GPT-4o Mini - Cost-effective option
     /// </summary>
-    Gpt4oMini
+    Gpt4oMini,
+
+    /// <summary>
+    /// Claude Haiku 4.5 - Fastest and most cost-effective Claude model (default)
+    /// </summary>
+    ClaudeHaiku45,
+
+    /// <summary>
+    /// Claude Sonnet 5 - Near-Opus quality at Sonnet cost
+    /// </summary>
+    ClaudeSonnet5,
+
+    /// <summary>
+    /// Claude Opus 4.8 - Most capable Claude model
+    /// </summary>
+    ClaudeOpus48
 }
 
 /// <summary>
@@ -32,7 +58,7 @@ public enum AIModel
 public static class AIModelHelper
 {
     /// <summary>
-    /// Convert AIModel enum to OpenAI API string
+    /// Convert AIModel enum to the provider API model string
     /// </summary>
     public static string ToApiString(this AIModel model) => model switch
     {
@@ -40,21 +66,44 @@ public static class AIModelHelper
         AIModel.Gpt41Mini => "gpt-4.1-mini",
         AIModel.Gpt4o => "gpt-4o",
         AIModel.Gpt4oMini => "gpt-4o-mini",
-        _ => "gpt-4o-mini" // Safe default
+        AIModel.ClaudeHaiku45 => "claude-haiku-4-5",
+        AIModel.ClaudeSonnet5 => "claude-sonnet-5",
+        AIModel.ClaudeOpus48 => "claude-opus-4-8",
+        _ => "claude-haiku-4-5" // Safe default
     };
-    
+
+    /// <summary>
+    /// Parse a provider API model string back to the AIModel enum.
+    /// Returns the application default when the string is unknown.
+    /// </summary>
+    public static AIModel FromApiString(string? apiString) => apiString?.ToLowerInvariant() switch
+    {
+        "gpt-4.1" => AIModel.Gpt41,
+        "gpt-4.1-mini" => AIModel.Gpt41Mini,
+        "gpt-4o" => AIModel.Gpt4o,
+        "gpt-4o-mini" => AIModel.Gpt4oMini,
+        "gpt-4-turbo" => AIModel.Gpt4o, // Legacy mapping
+        "claude-haiku-4-5" => AIModel.ClaudeHaiku45,
+        "claude-sonnet-5" => AIModel.ClaudeSonnet5,
+        "claude-opus-4-8" => AIModel.ClaudeOpus48,
+        _ => GetDefaultModel()
+    };
+
     /// <summary>
     /// Convert AIModel enum to user-friendly display name
     /// </summary>
     public static string ToDisplayName(this AIModel model) => model switch
     {
-        AIModel.Gpt41 => "GPT-4.1 (Most Capable)",
+        AIModel.Gpt41 => "GPT-4.1 (Most Capable GPT)",
         AIModel.Gpt41Mini => "GPT-4.1 Mini (Fast & Efficient)",
         AIModel.Gpt4o => "GPT-4o (Advanced)",
         AIModel.Gpt4oMini => "GPT-4o Mini (Cost Effective)",
-        _ => "GPT-4o Mini"
+        AIModel.ClaudeHaiku45 => "Claude Haiku 4.5 (Fast & Cost Effective)",
+        AIModel.ClaudeSonnet5 => "Claude Sonnet 5 (Balanced)",
+        AIModel.ClaudeOpus48 => "Claude Opus 4.8 (Most Capable)",
+        _ => "Claude Haiku 4.5"
     };
-    
+
     /// <summary>
     /// Get cost-effectiveness description for user guidance
     /// </summary>
@@ -64,16 +113,38 @@ public static class AIModelHelper
         AIModel.Gpt41Mini => "High quality, moderate cost",
         AIModel.Gpt4o => "Good quality, moderate cost",
         AIModel.Gpt4oMini => "Good quality, lowest cost",
+        AIModel.ClaudeHaiku45 => "Great quality, lowest Claude cost",
+        AIModel.ClaudeSonnet5 => "Near-Opus quality, moderate cost",
+        AIModel.ClaudeOpus48 => "Highest Claude quality, highest cost",
         _ => "Balanced option"
     };
-    
+
+    /// <summary>
+    /// Which provider serves this model
+    /// </summary>
+    public static AIProvider GetProvider(this AIModel model) => model switch
+    {
+        AIModel.ClaudeHaiku45 or AIModel.ClaudeSonnet5 or AIModel.ClaudeOpus48 => AIProvider.Anthropic,
+        _ => AIProvider.OpenAI
+    };
+
+    /// <summary>
+    /// Which provider serves this API model string (used for request routing)
+    /// </summary>
+    public static AIProvider GetProviderForApiString(string? apiString) =>
+        apiString != null && apiString.StartsWith("claude", StringComparison.OrdinalIgnoreCase)
+            ? AIProvider.Anthropic
+            : apiString == null
+                ? GetDefaultModel().GetProvider()
+                : AIProvider.OpenAI;
+
     /// <summary>
     /// Get all available models for dropdowns
     /// </summary>
     public static AIModel[] GetAllModels() => Enum.GetValues<AIModel>();
-    
+
     /// <summary>
-    /// Get default model for new users
+    /// Get default model for new users (Claude Haiku 4.5 — fast and cost-effective)
     /// </summary>
-    public static AIModel GetDefaultModel() => AIModel.Gpt4oMini;
-} 
+    public static AIModel GetDefaultModel() => AIModel.ClaudeHaiku45;
+}

--- a/src/DocFlowHub.Core/Models/AI/AISettings.cs
+++ b/src/DocFlowHub.Core/Models/AI/AISettings.cs
@@ -24,10 +24,10 @@ public class AISettings
     /// <summary>
     /// Preferred AI model for document processing
     /// </summary>
-    public AIModel PreferredModel { get; set; } = AIModel.Gpt4oMini;
-    
+    public AIModel PreferredModel { get; set; } = AIModel.ClaudeHaiku45;
+
     /// <summary>
-    /// Custom API key for OpenAI (if user wants to use their own)
+    /// Custom API key for the AI provider (if user wants to use their own)
     /// </summary>
     [StringLength(200)]
     public string? CustomApiKey { get; set; }
@@ -149,7 +149,7 @@ public static class AISettingsHelper
     public static AISettings GetDefaultSettings(string userId) => new()
     {
         UserId = userId,
-        PreferredModel = AIModel.Gpt4oMini,
+        PreferredModel = AIModel.ClaudeHaiku45,
         UseCustomApiKey = false,
         SummarizationEnabled = true,
         VersionComparisonEnabled = true,

--- a/src/DocFlowHub.Infrastructure/DependencyInjection.cs
+++ b/src/DocFlowHub.Infrastructure/DependencyInjection.cs
@@ -43,8 +43,12 @@ public static class DependencyInjection
         // Role Services
         services.AddScoped<IRoleService, RoleService>();
         
-        // AI Services
-        services.AddScoped<IAIService, OpenAIService>();
+        // AI Services — IAIService routes per requested model ("claude-*" → Anthropic,
+        // otherwise OpenAI). Provider services are registered as themselves and resolved
+        // lazily by the router, so only the provider actually used needs an API key.
+        services.AddScoped<OpenAIService>();
+        services.AddScoped<ClaudeAIService>();
+        services.AddScoped<IAIService, AIServiceRouter>();
         services.AddScoped<IDocumentSummaryService, DocumentSummaryService>();
         services.AddScoped<IVersionComparisonService, VersionComparisonService>();
         services.AddScoped<ITextExtractionService, TextExtractionService>();

--- a/src/DocFlowHub.Infrastructure/DependencyInjection.cs
+++ b/src/DocFlowHub.Infrastructure/DependencyInjection.cs
@@ -44,10 +44,12 @@ public static class DependencyInjection
         services.AddScoped<IRoleService, RoleService>();
         
         // AI Services — IAIService routes per requested model ("claude-*" → Anthropic,
-        // otherwise OpenAI). Provider services are registered as themselves and resolved
-        // lazily by the router, so only the provider actually used needs an API key.
-        services.AddScoped<OpenAIService>();
-        services.AddScoped<ClaudeAIService>();
+        // otherwise OpenAI). Provider services are stateless config holders wrapping a
+        // provider client (AnthropicClient / OpenAIClient), so they are SINGLETONS — this
+        // pools the underlying HttpClient/connections instead of rebuilding one per request.
+        // The router resolves them lazily, so only the provider actually used needs a key.
+        services.AddSingleton<OpenAIService>();
+        services.AddSingleton<ClaudeAIService>();
         services.AddScoped<IAIService, AIServiceRouter>();
         services.AddScoped<IDocumentSummaryService, DocumentSummaryService>();
         services.AddScoped<IVersionComparisonService, VersionComparisonService>();

--- a/src/DocFlowHub.Infrastructure/DocFlowHub.Infrastructure.csproj
+++ b/src/DocFlowHub.Infrastructure/DocFlowHub.Infrastructure.csproj
@@ -5,6 +5,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="DocumentFormat.OpenXml" Version="3.5.1" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -19,6 +20,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.4" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.19.1" />
     <PackageReference Include="OpenAI" Version="2.1.0" />
+    <PackageReference Include="PdfPig" Version="0.1.15" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DocFlowHub.Infrastructure/DocFlowHub.Infrastructure.csproj
+++ b/src/DocFlowHub.Infrastructure/DocFlowHub.Infrastructure.csproj
@@ -5,6 +5,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Anthropic" Version="12.35.1" />
     <PackageReference Include="DocumentFormat.OpenXml" Version="3.5.1" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.4">

--- a/src/DocFlowHub.Infrastructure/Services/AI/AIServiceRouter.cs
+++ b/src/DocFlowHub.Infrastructure/Services/AI/AIServiceRouter.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using DocFlowHub.Core.Services.Interfaces;
@@ -6,50 +7,86 @@ using DocFlowHub.Core.Models.AI;
 namespace DocFlowHub.Infrastructure.Services.AI;
 
 /// <summary>
-/// Routes AI requests to the correct provider (OpenAI or Anthropic) based on the
-/// requested model string ("claude-*" → Anthropic, otherwise OpenAI; null → the
-/// application default model's provider). Provider services are resolved lazily so
-/// a missing API key for a provider the user never selects does not break the app —
-/// it only surfaces as a failed AIResponse if a model from that provider is chosen.
+/// Routes AI requests to the correct provider (OpenAI or Anthropic).
+/// Completion requests route by the requested model string ("claude-*" → Anthropic,
+/// otherwise OpenAI; null → the application default model's provider). Health and
+/// connectivity checks probe whichever provider(s) are actually configured — NOT just
+/// the default — so an OpenAI-only (or Anthropic-only) deployment reports correctly.
+/// Provider services are resolved lazily; a missing key for a provider the user never
+/// selects surfaces only as a failed AIResponse, never a startup crash.
 /// </summary>
 public class AIServiceRouter : IAIService
 {
     private readonly IServiceProvider _services;
+    private readonly IConfiguration _configuration;
     private readonly ILogger<AIServiceRouter> _logger;
 
-    public AIServiceRouter(IServiceProvider services, ILogger<AIServiceRouter> logger)
+    public AIServiceRouter(IServiceProvider services, IConfiguration configuration, ILogger<AIServiceRouter> logger)
     {
         _services = services;
+        _configuration = configuration;
         _logger = logger;
     }
 
-    public Task<bool> TestConnectivityAsync()
+    public async Task<bool> TestConnectivityAsync()
     {
-        var (service, _) = Resolve(null);
-        return service is null ? Task.FromResult(false) : service.TestConnectivityAsync();
+        var providers = ConfiguredProviders().ToList();
+        if (providers.Count == 0)
+        {
+            return false;
+        }
+
+        foreach (var provider in providers)
+        {
+            var (service, _) = Resolve(provider);
+            if (service is not null && await service.TestConnectivityAsync())
+            {
+                return true; // healthy if any configured provider connects
+            }
+        }
+
+        return false;
     }
 
     public async Task<AIServiceHealth> GetHealthAsync()
     {
-        var (service, error) = Resolve(null);
-        if (service is null)
+        var providers = ConfiguredProviders().ToList();
+        if (providers.Count == 0)
         {
             return new AIServiceHealth
             {
                 IsHealthy = false,
                 ResponseTime = TimeSpan.Zero,
                 CheckedAt = DateTime.UtcNow,
-                Status = "AI provider is not configured",
-                ErrorMessage = error
+                Status = "No AI provider is configured (set OpenAI:ApiKey or Anthropic:ApiKey)"
             };
         }
 
-        return await service.GetHealthAsync();
+        AIServiceHealth? lastResult = null;
+        foreach (var provider in providers)
+        {
+            var (service, error) = Resolve(provider);
+            if (service is null)
+            {
+                lastResult = Unhealthy(provider, error);
+                continue;
+            }
+
+            var health = await service.GetHealthAsync();
+            health.Status = $"[{provider}] {health.Status}";
+            if (health.IsHealthy)
+            {
+                return health; // first healthy provider wins
+            }
+            lastResult = health;
+        }
+
+        return lastResult!; // no provider healthy — surface the last error
     }
 
     public async Task<AIResponse> GenerateCompletionAsync(string prompt, string? model = null)
     {
-        var (service, error) = Resolve(model);
+        var (service, error) = Resolve(AIModelHelper.GetProviderForApiString(model));
         return service is null
             ? Failure(model, error)
             : await service.GenerateCompletionAsync(prompt, model);
@@ -57,20 +94,46 @@ public class AIServiceRouter : IAIService
 
     public async Task<AIResponse> GenerateCompletionAsync(string prompt, string systemMessage, string? model = null)
     {
-        var (service, error) = Resolve(model);
+        var (service, error) = Resolve(AIModelHelper.GetProviderForApiString(model));
         return service is null
             ? Failure(model, error)
             : await service.GenerateCompletionAsync(prompt, systemMessage, model);
     }
 
     /// <summary>
-    /// Resolve the provider service for the requested model. Construction can throw
-    /// (missing API key) — converted here into a (null, error) result so callers get
-    /// a clean failed AIResponse instead of a 500.
+    /// The providers that have an API key configured. Health checks only probe these,
+    /// so a valid OpenAI key isn't reported invalid just because Anthropic is the default.
     /// </summary>
-    private (IAIService? Service, string? Error) Resolve(string? model)
+    private IEnumerable<AIProvider> ConfiguredProviders()
     {
-        var provider = AIModelHelper.GetProviderForApiString(model);
+        // Probe the application default's provider first so the "primary" path is checked first.
+        var defaultProvider = AIModelHelper.GetDefaultModel().GetProvider();
+        foreach (var provider in new[] { defaultProvider, Other(defaultProvider) })
+        {
+            if (IsConfigured(provider))
+            {
+                yield return provider;
+            }
+        }
+    }
+
+    private bool IsConfigured(AIProvider provider)
+    {
+        var key = provider == AIProvider.Anthropic
+            ? _configuration["Anthropic:ApiKey"]
+            : _configuration["OpenAI:ApiKey"];
+        return !string.IsNullOrWhiteSpace(key);
+    }
+
+    private static AIProvider Other(AIProvider provider)
+        => provider == AIProvider.Anthropic ? AIProvider.OpenAI : AIProvider.Anthropic;
+
+    /// <summary>
+    /// Resolve the provider service. Construction can throw (missing API key) — converted
+    /// here into a (null, error) result so callers get a clean failed AIResponse, not a 500.
+    /// </summary>
+    private (IAIService? Service, string? Error) Resolve(AIProvider provider)
+    {
         try
         {
             IAIService service = provider == AIProvider.Anthropic
@@ -80,10 +143,19 @@ public class AIServiceRouter : IAIService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to resolve AI provider {Provider} for model '{Model}'", provider, model);
+            _logger.LogError(ex, "Failed to resolve AI provider {Provider}", provider);
             return (null, $"{provider} is not configured: {ex.Message}");
         }
     }
+
+    private static AIServiceHealth Unhealthy(AIProvider provider, string? error) => new()
+    {
+        IsHealthy = false,
+        ResponseTime = TimeSpan.Zero,
+        CheckedAt = DateTime.UtcNow,
+        Status = $"[{provider}] not configured",
+        ErrorMessage = error
+    };
 
     private static AIResponse Failure(string? model, string? error) => new()
     {

--- a/src/DocFlowHub.Infrastructure/Services/AI/AIServiceRouter.cs
+++ b/src/DocFlowHub.Infrastructure/Services/AI/AIServiceRouter.cs
@@ -1,0 +1,98 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using DocFlowHub.Core.Services.Interfaces;
+using DocFlowHub.Core.Models.AI;
+
+namespace DocFlowHub.Infrastructure.Services.AI;
+
+/// <summary>
+/// Routes AI requests to the correct provider (OpenAI or Anthropic) based on the
+/// requested model string ("claude-*" → Anthropic, otherwise OpenAI; null → the
+/// application default model's provider). Provider services are resolved lazily so
+/// a missing API key for a provider the user never selects does not break the app —
+/// it only surfaces as a failed AIResponse if a model from that provider is chosen.
+/// </summary>
+public class AIServiceRouter : IAIService
+{
+    private readonly IServiceProvider _services;
+    private readonly ILogger<AIServiceRouter> _logger;
+
+    public AIServiceRouter(IServiceProvider services, ILogger<AIServiceRouter> logger)
+    {
+        _services = services;
+        _logger = logger;
+    }
+
+    public Task<bool> TestConnectivityAsync()
+    {
+        var (service, _) = Resolve(null);
+        return service is null ? Task.FromResult(false) : service.TestConnectivityAsync();
+    }
+
+    public async Task<AIServiceHealth> GetHealthAsync()
+    {
+        var (service, error) = Resolve(null);
+        if (service is null)
+        {
+            return new AIServiceHealth
+            {
+                IsHealthy = false,
+                ResponseTime = TimeSpan.Zero,
+                CheckedAt = DateTime.UtcNow,
+                Status = "AI provider is not configured",
+                ErrorMessage = error
+            };
+        }
+
+        return await service.GetHealthAsync();
+    }
+
+    public async Task<AIResponse> GenerateCompletionAsync(string prompt, string? model = null)
+    {
+        var (service, error) = Resolve(model);
+        return service is null
+            ? Failure(model, error)
+            : await service.GenerateCompletionAsync(prompt, model);
+    }
+
+    public async Task<AIResponse> GenerateCompletionAsync(string prompt, string systemMessage, string? model = null)
+    {
+        var (service, error) = Resolve(model);
+        return service is null
+            ? Failure(model, error)
+            : await service.GenerateCompletionAsync(prompt, systemMessage, model);
+    }
+
+    /// <summary>
+    /// Resolve the provider service for the requested model. Construction can throw
+    /// (missing API key) — converted here into a (null, error) result so callers get
+    /// a clean failed AIResponse instead of a 500.
+    /// </summary>
+    private (IAIService? Service, string? Error) Resolve(string? model)
+    {
+        var provider = AIModelHelper.GetProviderForApiString(model);
+        try
+        {
+            IAIService service = provider == AIProvider.Anthropic
+                ? _services.GetRequiredService<ClaudeAIService>()
+                : _services.GetRequiredService<OpenAIService>();
+            return (service, null);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to resolve AI provider {Provider} for model '{Model}'", provider, model);
+            return (null, $"{provider} is not configured: {ex.Message}");
+        }
+    }
+
+    private static AIResponse Failure(string? model, string? error) => new()
+    {
+        Content = string.Empty,
+        Model = model ?? AIModelHelper.GetDefaultModel().ToApiString(),
+        TokensUsed = 0,
+        ResponseTime = TimeSpan.Zero,
+        IsSuccess = false,
+        ErrorMessage = error ?? "AI provider is not configured",
+        GeneratedAt = DateTime.UtcNow
+    };
+}

--- a/src/DocFlowHub.Infrastructure/Services/AI/AISettingsService.cs
+++ b/src/DocFlowHub.Infrastructure/Services/AI/AISettingsService.cs
@@ -481,6 +481,9 @@ public class AISettingsService : IAISettingsService
         AIModel.Gpt4o => "Medium",
         AIModel.Gpt41Mini => "Medium",
         AIModel.Gpt41 => "High",
+        AIModel.ClaudeHaiku45 => "Low",
+        AIModel.ClaudeSonnet5 => "Medium",
+        AIModel.ClaudeOpus48 => "High",
         _ => "Medium"
     };
 
@@ -490,6 +493,9 @@ public class AISettingsService : IAISettingsService
         AIModel.Gpt4o => 8000,
         AIModel.Gpt41Mini => 16000,
         AIModel.Gpt41 => 8000,
+        AIModel.ClaudeHaiku45 => 64000,
+        AIModel.ClaudeSonnet5 => 64000,
+        AIModel.ClaudeOpus48 => 32000,
         _ => 8000
     };
 } 

--- a/src/DocFlowHub.Infrastructure/Services/AI/AISettingsService.cs
+++ b/src/DocFlowHub.Infrastructure/Services/AI/AISettingsService.cs
@@ -299,7 +299,7 @@ public class AISettingsService : IAISettingsService
                     DisplayName = model.ToDisplayName(),
                     Description = model.GetCostDescription(),
                     CostLevel = GetCostLevel(model),
-                    IsRecommended = model == AIModel.Gpt4oMini,
+                    IsRecommended = model == AIModel.ClaudeHaiku45,
                     MaxTokens = GetMaxTokens(model)
                 });
             }

--- a/src/DocFlowHub.Infrastructure/Services/AI/AIUsageTrackingService.cs
+++ b/src/DocFlowHub.Infrastructure/Services/AI/AIUsageTrackingService.cs
@@ -29,7 +29,11 @@ public class AIUsageTrackingService : IAIUsageTrackingService
         ["gpt-4o-mini"] = 0.000150m,
         ["gpt-4.1"] = 0.003m,
         ["gpt-4.1-mini"] = 0.000200m,
-        ["gpt-3.5-turbo"] = 0.001m
+        ["gpt-3.5-turbo"] = 0.001m,
+        // Anthropic Claude — input price per 1K tokens
+        ["claude-haiku-4-5"] = 0.001m,
+        ["claude-sonnet-5"] = 0.003m,
+        ["claude-opus-4-8"] = 0.005m
     };
 
     public AIUsageTrackingService(
@@ -115,8 +119,9 @@ public class AIUsageTrackingService : IAIUsageTrackingService
             return (estimatedTokens / 1000m) * costPer1K;
         }
 
-        // Default to GPT-4o-mini cost if model not found
-        return (estimatedTokens / 1000m) * ModelCosts["gpt-4o-mini"];
+        // Unknown model: fall back to the application's default model cost
+        var fallback = AIModelHelper.GetDefaultModel().ToApiString();
+        return (estimatedTokens / 1000m) * ModelCosts[fallback];
     }
 
     /// <summary>
@@ -621,16 +626,7 @@ public class AIUsageTrackingService : IAIUsageTrackingService
     #region Helper Methods
 
     private static AIModel ParseModelString(string modelString)
-    {
-        return modelString.ToLower() switch
-        {
-            "gpt-4o" => AIModel.Gpt4o,
-            "gpt-4o-mini" => AIModel.Gpt4oMini,
-            "gpt-4.1" => AIModel.Gpt41,
-            "gpt-4.1-mini" => AIModel.Gpt41Mini,
-            _ => AIModel.Gpt4oMini
-        };
-    }
+        => AIModelHelper.FromApiString(modelString);
 
     private string GetUserEmail(string userId)
     {

--- a/src/DocFlowHub.Infrastructure/Services/AI/ClaudeAIService.cs
+++ b/src/DocFlowHub.Infrastructure/Services/AI/ClaudeAIService.cs
@@ -1,0 +1,207 @@
+using Anthropic;
+using Anthropic.Models.Messages;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using DocFlowHub.Core.Services.Interfaces;
+using DocFlowHub.Core.Models.AI;
+using System.Diagnostics;
+
+namespace DocFlowHub.Infrastructure.Services.AI;
+
+/// <summary>
+/// Anthropic Claude implementation of <see cref="IAIService"/>.
+/// The SDK auto-retries transient failures (429/5xx/network) with exponential backoff,
+/// so unlike OpenAIService no hand-rolled retry loop is needed here.
+/// </summary>
+public class ClaudeAIService : IAIService
+{
+    private readonly AnthropicClient _client;
+    private readonly ILogger<ClaudeAIService> _logger;
+    private readonly string _defaultModel;
+    private readonly long _maxTokens;
+
+    public ClaudeAIService(IConfiguration configuration, ILogger<ClaudeAIService> logger)
+    {
+        var apiKey = configuration["Anthropic:ApiKey"];
+        if (string.IsNullOrEmpty(apiKey))
+        {
+            throw new InvalidOperationException(
+                "Anthropic API key is not configured. Please set Anthropic:ApiKey via user-secrets or appsettings.");
+        }
+
+        _client = new AnthropicClient { ApiKey = apiKey };
+        _logger = logger;
+        _defaultModel = configuration["Anthropic:Model"] ?? AIModel.ClaudeHaiku45.ToApiString();
+        _maxTokens = long.TryParse(configuration["Anthropic:MaxTokens"], out var maxTokens) ? maxTokens : 4096;
+
+        _logger.LogInformation("Anthropic Claude service initialized with default model: {Model}", _defaultModel);
+    }
+
+    /// <summary>
+    /// Test connectivity to the Anthropic API
+    /// </summary>
+    public async Task<bool> TestConnectivityAsync()
+    {
+        try
+        {
+            _logger.LogInformation("Testing Anthropic Claude service connectivity...");
+
+            var response = await CreateMessageAsync(
+                "Test connection",
+                "You are a helpful assistant. Respond with just 'OK' to test connectivity.",
+                _defaultModel);
+
+            _logger.LogInformation("Anthropic connectivity test successful. Response: {Response}", GetText(response));
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Anthropic Claude service connectivity test failed");
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Get AI service health status
+    /// </summary>
+    public async Task<AIServiceHealth> GetHealthAsync()
+    {
+        try
+        {
+            var stopwatch = Stopwatch.StartNew();
+            bool isConnected = await TestConnectivityAsync();
+            stopwatch.Stop();
+
+            return new AIServiceHealth
+            {
+                IsHealthy = isConnected,
+                ResponseTime = stopwatch.Elapsed,
+                CheckedAt = DateTime.UtcNow,
+                Status = isConnected ? "Connected to Anthropic API successfully" : "Failed to connect to Anthropic API"
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Anthropic Claude service health check failed");
+            return new AIServiceHealth
+            {
+                IsHealthy = false,
+                ResponseTime = TimeSpan.Zero,
+                CheckedAt = DateTime.UtcNow,
+                Status = "Failed to check AI service health",
+                ErrorMessage = ex.Message
+            };
+        }
+    }
+
+    /// <summary>
+    /// Generate a completion using the specified model
+    /// </summary>
+    public Task<AIResponse> GenerateCompletionAsync(string prompt, string? model = null)
+        => GenerateAsync(prompt, systemMessage: null, model);
+
+    /// <summary>
+    /// Generate a completion with system message and user prompt
+    /// </summary>
+    public Task<AIResponse> GenerateCompletionAsync(string prompt, string systemMessage, string? model = null)
+        => GenerateAsync(prompt, systemMessage, model);
+
+    private async Task<AIResponse> GenerateAsync(string prompt, string? systemMessage, string? model)
+    {
+        var selectedModel = ResolveModel(model);
+
+        try
+        {
+            _logger.LogInformation(
+                "Generating Claude completion for prompt length: {Length} characters using model: {Model}",
+                prompt.Length, selectedModel);
+
+            var stopwatch = Stopwatch.StartNew();
+            var response = await CreateMessageAsync(prompt, systemMessage, selectedModel);
+            stopwatch.Stop();
+
+            var content = GetText(response);
+            var tokensUsed = (int)(response.Usage.InputTokens + response.Usage.OutputTokens);
+
+            _logger.LogInformation(
+                "Claude completion generated successfully. Response length: {Length} characters, Tokens used: {Tokens}",
+                content.Length, tokensUsed);
+
+            return new AIResponse
+            {
+                Content = content,
+                Model = selectedModel,
+                TokensUsed = tokensUsed,
+                ResponseTime = stopwatch.Elapsed,
+                IsSuccess = true,
+                GeneratedAt = DateTime.UtcNow
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to generate Claude completion");
+            return new AIResponse
+            {
+                Content = string.Empty,
+                Model = selectedModel,
+                TokensUsed = 0,
+                ResponseTime = TimeSpan.Zero,
+                IsSuccess = false,
+                ErrorMessage = ex.Message,
+                GeneratedAt = DateTime.UtcNow
+            };
+        }
+    }
+
+    private async Task<Message> CreateMessageAsync(string prompt, string? systemMessage, string model)
+    {
+        // Role is fully qualified to avoid collision with DocFlowHub.Infrastructure.Services.Role
+        var userMessage = new MessageParam
+        {
+            Role = Anthropic.Models.Messages.Role.User,
+            Content = prompt
+        };
+
+        var parameters = string.IsNullOrEmpty(systemMessage)
+            ? new MessageCreateParams
+            {
+                Model = model,
+                MaxTokens = _maxTokens,
+                Messages = [userMessage]
+            }
+            : new MessageCreateParams
+            {
+                Model = model,
+                MaxTokens = _maxTokens,
+                System = systemMessage,
+                Messages = [userMessage]
+            };
+
+        return await _client.Messages.Create(parameters);
+    }
+
+    private static string GetText(Message response)
+        => string.Concat(response.Content.Select(b => b.Value).OfType<TextBlock>().Select(t => t.Text));
+
+    /// <summary>
+    /// Guard against cross-provider model strings: if a non-Claude model (e.g. a user's
+    /// stored GPT preference) reaches this service, fall back to the configured default.
+    /// </summary>
+    private string ResolveModel(string? model)
+    {
+        if (string.IsNullOrEmpty(model))
+        {
+            return _defaultModel;
+        }
+
+        if (!model.StartsWith("claude", StringComparison.OrdinalIgnoreCase))
+        {
+            _logger.LogWarning(
+                "Non-Claude model '{Model}' requested from ClaudeAIService; falling back to {Default}",
+                model, _defaultModel);
+            return _defaultModel;
+        }
+
+        return model;
+    }
+}

--- a/src/DocFlowHub.Infrastructure/Services/AI/DocumentSummaryService.cs
+++ b/src/DocFlowHub.Infrastructure/Services/AI/DocumentSummaryService.cs
@@ -83,7 +83,7 @@ public class DocumentSummaryService : IDocumentSummaryService
     /// </summary>
     public async Task<ServiceResult<DocumentSummary>> GenerateSummaryAsync(int documentId)
     {
-        return await GenerateSummaryAsync(documentId, AIModel.Gpt4oMini);
+        return await GenerateSummaryAsync(documentId, AIModelHelper.GetDefaultModel());
     }
 
     /// <summary>
@@ -174,7 +174,7 @@ Summary:";
     /// </summary>
     public async Task<ServiceResult> RegenerateSummaryAsync(int documentId)
     {
-        return await RegenerateSummaryAsync(documentId, AIModel.Gpt4oMini);
+        return await RegenerateSummaryAsync(documentId, AIModelHelper.GetDefaultModel());
     }
 
     /// <summary>

--- a/src/DocFlowHub.Infrastructure/Services/AI/OpenAIService.cs
+++ b/src/DocFlowHub.Infrastructure/Services/AI/OpenAIService.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Caching.Memory;
 using DocFlowHub.Core.Services.Interfaces;
 using DocFlowHub.Core.Models.AI;
 using System.Diagnostics;
+using System.ClientModel;
 
 namespace DocFlowHub.Infrastructure.Services.AI;
 
@@ -52,7 +53,7 @@ public class OpenAIService : IAIService
                 new UserChatMessage("Test connection")
             };
 
-            var response = await chatClient.CompleteChatAsync(messages);
+            var response = await CompleteChatWithRetryAsync(chatClient, messages);
             var content = response.Value.Content[0].Text;
 
             _logger.LogInformation("OpenAI connectivity test successful. Response: {Response}", content);
@@ -117,7 +118,7 @@ public class OpenAIService : IAIService
                 new UserChatMessage(prompt)
             };
 
-            var response = await chatClient.CompleteChatAsync(messages);
+            var response = await CompleteChatWithRetryAsync(chatClient, messages);
             stopwatch.Stop();
             
             var content = response.Value.Content[0].Text;
@@ -171,7 +172,7 @@ public class OpenAIService : IAIService
                 new UserChatMessage(prompt)
             };
 
-            var response = await chatClient.CompleteChatAsync(messages);
+            var response = await CompleteChatWithRetryAsync(chatClient, messages);
             stopwatch.Stop();
             
             var content = response.Value.Content[0].Text;
@@ -203,5 +204,49 @@ public class OpenAIService : IAIService
                 GeneratedAt = DateTime.UtcNow
             };
         }
+    }
+
+    /// <summary>
+    /// Calls the OpenAI chat completion endpoint with exponential-backoff retries on
+    /// transient failures (HTTP 429 rate limits, 5xx, and network glitches). Non-transient
+    /// errors (e.g. 400/401) are thrown immediately so callers surface them without delay.
+    /// </summary>
+    private async Task<ClientResult<ChatCompletion>> CompleteChatWithRetryAsync(
+        ChatClient chatClient, List<ChatMessage> messages)
+    {
+        const int maxAttempts = 3;
+        var delay = TimeSpan.FromSeconds(1);
+
+        for (var attempt = 1; ; attempt++)
+        {
+            try
+            {
+                return await chatClient.CompleteChatAsync(messages);
+            }
+            catch (Exception ex) when (attempt < maxAttempts && IsTransient(ex))
+            {
+                _logger.LogWarning(ex,
+                    "Transient OpenAI failure on attempt {Attempt}/{MaxAttempts}; retrying in {Delay}s",
+                    attempt, maxAttempts, delay.TotalSeconds);
+                await Task.Delay(delay);
+                delay *= 2;
+            }
+        }
+    }
+
+    /// <summary>
+    /// A failure is transient (worth retrying) if it is a rate-limit/server-side error
+    /// from OpenAI or a transport-level network error.
+    /// </summary>
+    private static bool IsTransient(Exception ex)
+    {
+        if (ex is ClientResultException clientError)
+        {
+            return clientError.Status == 429 || clientError.Status >= 500;
+        }
+
+        return ex is System.Net.Http.HttpRequestException
+            or TaskCanceledException
+            or TimeoutException;
     }
 } 

--- a/src/DocFlowHub.Infrastructure/Services/AI/OpenAIService.cs
+++ b/src/DocFlowHub.Infrastructure/Services/AI/OpenAIService.cs
@@ -6,7 +6,6 @@ using Microsoft.Extensions.Caching.Memory;
 using DocFlowHub.Core.Services.Interfaces;
 using DocFlowHub.Core.Models.AI;
 using System.Diagnostics;
-using System.ClientModel;
 
 namespace DocFlowHub.Infrastructure.Services.AI;
 
@@ -53,7 +52,7 @@ public class OpenAIService : IAIService
                 new UserChatMessage("Test connection")
             };
 
-            var response = await CompleteChatWithRetryAsync(chatClient, messages);
+            var response = await chatClient.CompleteChatAsync(messages);
             var content = response.Value.Content[0].Text;
 
             _logger.LogInformation("OpenAI connectivity test successful. Response: {Response}", content);
@@ -118,7 +117,7 @@ public class OpenAIService : IAIService
                 new UserChatMessage(prompt)
             };
 
-            var response = await CompleteChatWithRetryAsync(chatClient, messages);
+            var response = await chatClient.CompleteChatAsync(messages);
             stopwatch.Stop();
             
             var content = response.Value.Content[0].Text;
@@ -172,7 +171,7 @@ public class OpenAIService : IAIService
                 new UserChatMessage(prompt)
             };
 
-            var response = await CompleteChatWithRetryAsync(chatClient, messages);
+            var response = await chatClient.CompleteChatAsync(messages);
             stopwatch.Stop();
             
             var content = response.Value.Content[0].Text;
@@ -206,47 +205,4 @@ public class OpenAIService : IAIService
         }
     }
 
-    /// <summary>
-    /// Calls the OpenAI chat completion endpoint with exponential-backoff retries on
-    /// transient failures (HTTP 429 rate limits, 5xx, and network glitches). Non-transient
-    /// errors (e.g. 400/401) are thrown immediately so callers surface them without delay.
-    /// </summary>
-    private async Task<ClientResult<ChatCompletion>> CompleteChatWithRetryAsync(
-        ChatClient chatClient, List<ChatMessage> messages)
-    {
-        const int maxAttempts = 3;
-        var delay = TimeSpan.FromSeconds(1);
-
-        for (var attempt = 1; ; attempt++)
-        {
-            try
-            {
-                return await chatClient.CompleteChatAsync(messages);
-            }
-            catch (Exception ex) when (attempt < maxAttempts && IsTransient(ex))
-            {
-                _logger.LogWarning(ex,
-                    "Transient OpenAI failure on attempt {Attempt}/{MaxAttempts}; retrying in {Delay}s",
-                    attempt, maxAttempts, delay.TotalSeconds);
-                await Task.Delay(delay);
-                delay *= 2;
-            }
-        }
-    }
-
-    /// <summary>
-    /// A failure is transient (worth retrying) if it is a rate-limit/server-side error
-    /// from OpenAI or a transport-level network error.
-    /// </summary>
-    private static bool IsTransient(Exception ex)
-    {
-        if (ex is ClientResultException clientError)
-        {
-            return clientError.Status == 429 || clientError.Status >= 500;
-        }
-
-        return ex is System.Net.Http.HttpRequestException
-            or TaskCanceledException
-            or TimeoutException;
-    }
 } 

--- a/src/DocFlowHub.Infrastructure/Services/AI/TextExtractionService.cs
+++ b/src/DocFlowHub.Infrastructure/Services/AI/TextExtractionService.cs
@@ -4,6 +4,10 @@ using DocFlowHub.Infrastructure.Data;
 using Microsoft.Extensions.Logging;
 using Microsoft.EntityFrameworkCore;
 using System.Text;
+using UglyToad.PdfPig;
+using UglyToad.PdfPig.DocumentLayoutAnalysis.TextExtractor;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
 
 namespace DocFlowHub.Infrastructure.Services.AI;
 
@@ -211,117 +215,80 @@ public class TextExtractionService : ITextExtractionService
     }
 
     /// <summary>
-    /// Extract text from PDF file
+    /// Extract text from a PDF file using PdfPig (content-ordered, page by page).
+    /// Returns an empty string on failure so the caller reports "no text extracted"
+    /// rather than feeding a placeholder to the AI summarizer.
     /// </summary>
-    private async Task<string> ExtractFromPdfFileAsync(byte[] fileContent, string fileName)
+    private Task<string> ExtractFromPdfFileAsync(byte[] fileContent, string fileName)
     {
         try
         {
-            // TODO: Implement PDF text extraction using a library like iTextSharp or PdfPig
-            // For now, return a placeholder indicating PDF processing is needed
-            _logger.LogInformation("PDF text extraction not yet implemented for file: {FileName}", fileName);
-            
-            // Basic fallback - try to extract any readable text
-            var fallbackText = await ExtractFallbackTextAsync(fileContent);
-            return !string.IsNullOrWhiteSpace(fallbackText) 
-                ? $"[PDF Content - Basic Extraction]\n{fallbackText}" 
-                : "[PDF Document - Text extraction requires specialized library]";
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error processing PDF file: {FileName}", fileName);
-            return "[PDF Document - Text extraction failed]";
-        }
-    }
-
-    /// <summary>
-    /// Extract text from DOC file
-    /// </summary>
-    private async Task<string> ExtractFromDocFileAsync(byte[] fileContent, string fileName)
-    {
-        try
-        {
-            // TODO: Implement DOC text extraction using a library like Aspose.Words or similar
-            _logger.LogInformation("DOC text extraction not yet implemented for file: {FileName}", fileName);
-            
-            var fallbackText = await ExtractFallbackTextAsync(fileContent);
-            return !string.IsNullOrWhiteSpace(fallbackText) 
-                ? $"[DOC Content - Basic Extraction]\n{fallbackText}" 
-                : "[DOC Document - Text extraction requires specialized library]";
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error processing DOC file: {FileName}", fileName);
-            return "[DOC Document - Text extraction failed]";
-        }
-    }
-
-    /// <summary>
-    /// Extract text from DOCX file
-    /// </summary>
-    private async Task<string> ExtractFromDocxFileAsync(byte[] fileContent, string fileName)
-    {
-        try
-        {
-            // TODO: Implement DOCX text extraction using DocumentFormat.OpenXml
-            _logger.LogInformation("DOCX text extraction not yet implemented for file: {FileName}", fileName);
-            
-            var fallbackText = await ExtractFallbackTextAsync(fileContent);
-            return !string.IsNullOrWhiteSpace(fallbackText) 
-                ? $"[DOCX Content - Basic Extraction]\n{fallbackText}" 
-                : "[DOCX Document - Text extraction requires specialized library]";
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error processing DOCX file: {FileName}", fileName);
-            return "[DOCX Document - Text extraction failed]";
-        }
-    }
-
-    /// <summary>
-    /// Fallback text extraction for binary files - attempts to find readable text
-    /// </summary>
-    private async Task<string> ExtractFallbackTextAsync(byte[] fileContent)
-    {
-        try
-        {
-            var text = Encoding.UTF8.GetString(fileContent);
+            using var pdf = PdfDocument.Open(fileContent);
             var builder = new StringBuilder();
-            
-            // Extract sequences of printable characters
-            var currentWord = new StringBuilder();
-            foreach (char c in text)
+            foreach (var page in pdf.GetPages())
             {
-                if (char.IsLetterOrDigit(c) || char.IsPunctuation(c) || char.IsWhiteSpace(c))
+                var pageText = ContentOrderTextExtractor.GetText(page);
+                if (!string.IsNullOrWhiteSpace(pageText))
                 {
-                    currentWord.Append(c);
-                }
-                else
-                {
-                    if (currentWord.Length > 3) // Only keep words with 4+ characters
-                    {
-                        builder.Append(currentWord.ToString().Trim()).Append(' ');
-                    }
-                    currentWord.Clear();
+                    builder.AppendLine(pageText);
                 }
             }
-            
-            // Add the last word if it's long enough
-            if (currentWord.Length > 3)
+            return Task.FromResult(builder.ToString().Trim());
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error extracting text from PDF file: {FileName}", fileName);
+            return Task.FromResult(string.Empty);
+        }
+    }
+
+    /// <summary>
+    /// Legacy binary .doc (OLE2/Word 97-2003). No maintained free/OSS .NET extractor is
+    /// available (NPOI ships no HWPF; the alternatives are commercial/limited), so this
+    /// degrades gracefully: it logs and returns an empty string, which makes the caller
+    /// report "no text could be extracted" instead of feeding garbage to the summarizer.
+    /// Modern .docx is fully supported via <see cref="ExtractFromDocxFileAsync"/>.
+    /// </summary>
+    private Task<string> ExtractFromDocFileAsync(byte[] fileContent, string fileName)
+    {
+        _logger.LogWarning(
+            "Legacy binary .doc text extraction is not supported (no OSS extractor). " +
+            "Skipping AI text extraction for file: {FileName}. Re-save as .docx or .pdf for AI summaries.",
+            fileName);
+        return Task.FromResult(string.Empty);
+    }
+
+    /// <summary>
+    /// Extract text from a .docx file using the OpenXML SDK, one paragraph per line.
+    /// Returns an empty string on failure.
+    /// </summary>
+    private Task<string> ExtractFromDocxFileAsync(byte[] fileContent, string fileName)
+    {
+        try
+        {
+            using var stream = new MemoryStream(fileContent);
+            using var wordDoc = WordprocessingDocument.Open(stream, false);
+            var body = wordDoc.MainDocumentPart?.Document?.Body;
+            if (body == null)
             {
-                builder.Append(currentWord.ToString().Trim());
+                return Task.FromResult(string.Empty);
             }
 
-            var extractedText = builder.ToString().Trim();
-            
-            // Clean up multiple spaces and limit length
-            var cleanedText = System.Text.RegularExpressions.Regex.Replace(extractedText, @"\s+", " ");
-            
-            return await Task.FromResult(cleanedText.Length > 500 ? cleanedText.Substring(0, 500) + "..." : cleanedText);
+            var builder = new StringBuilder();
+            foreach (var paragraph in body.Descendants<Paragraph>())
+            {
+                var paragraphText = paragraph.InnerText;
+                if (!string.IsNullOrWhiteSpace(paragraphText))
+                {
+                    builder.AppendLine(paragraphText);
+                }
+            }
+            return Task.FromResult(builder.ToString().Trim());
         }
-        catch
+        catch (Exception ex)
         {
-            return await Task.FromResult(string.Empty);
+            _logger.LogError(ex, "Error extracting text from DOCX file: {FileName}", fileName);
+            return Task.FromResult(string.Empty);
         }
     }
 } 

--- a/src/DocFlowHub.Infrastructure/Services/AI/VersionComparisonService.cs
+++ b/src/DocFlowHub.Infrastructure/Services/AI/VersionComparisonService.cs
@@ -47,7 +47,7 @@ public class VersionComparisonService : IVersionComparisonService
     /// </summary>
     public async Task<ServiceResult<VersionComparison>> CompareVersionsAsync(int fromVersionId, int toVersionId)
     {
-        return await CompareVersionsAsync(fromVersionId, toVersionId, AIModel.Gpt4oMini);
+        return await CompareVersionsAsync(fromVersionId, toVersionId, AIModelHelper.GetDefaultModel());
     }
 
     /// <summary>
@@ -152,7 +152,7 @@ public class VersionComparisonService : IVersionComparisonService
     /// </summary>
     public async Task<ServiceResult<VersionComparison>> CompareDocumentVersionsAsync(int documentId, int fromVersionNumber, int toVersionNumber)
     {
-        return await CompareDocumentVersionsAsync(documentId, fromVersionNumber, toVersionNumber, AIModel.Gpt4oMini);
+        return await CompareDocumentVersionsAsync(documentId, fromVersionNumber, toVersionNumber, AIModelHelper.GetDefaultModel());
     }
 
     /// <summary>
@@ -191,7 +191,7 @@ public class VersionComparisonService : IVersionComparisonService
     /// </summary>
     public async Task<ServiceResult<VersionComparison>> CompareVersionsAsync(int fromVersionId, int toVersionId, string userId)
     {
-        return await CompareVersionsAsync(fromVersionId, toVersionId, AIModel.Gpt4oMini, userId);
+        return await CompareVersionsAsync(fromVersionId, toVersionId, AIModelHelper.GetDefaultModel(), userId);
     }
 
     /// <summary>
@@ -296,7 +296,7 @@ public class VersionComparisonService : IVersionComparisonService
     /// </summary>
     public async Task<ServiceResult<VersionComparison>> CompareDocumentVersionsAsync(int documentId, int fromVersionNumber, int toVersionNumber, string userId)
     {
-        return await CompareDocumentVersionsAsync(documentId, fromVersionNumber, toVersionNumber, AIModel.Gpt4oMini, userId);
+        return await CompareDocumentVersionsAsync(documentId, fromVersionNumber, toVersionNumber, AIModelHelper.GetDefaultModel(), userId);
     }
 
     /// <summary>

--- a/src/DocFlowHub.Infrastructure/Services/Profile/ProfileService.cs
+++ b/src/DocFlowHub.Infrastructure/Services/Profile/ProfileService.cs
@@ -3,6 +3,7 @@ using DocFlowHub.Core.Models.Common;
 using DocFlowHub.Core.Models.Profile;
 using DocFlowHub.Core.Services.Interfaces;
 using DocFlowHub.Infrastructure.Data;
+using DocFlowHub.Infrastructure.Services.Storage;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
@@ -12,6 +13,12 @@ namespace DocFlowHub.Infrastructure.Services.Profile;
 
 public class ProfileService : IProfileService
 {
+    // Profile pictures are served from wwwroot under the site origin, so an unvalidated
+    // upload (e.g. .html/.svg mislabeled as an image) is a stored-XSS vector. Restrict to
+    // real image types AND verify the bytes match the extension via FileSignatureValidator.
+    private static readonly string[] AllowedImageExtensions = { ".jpg", ".jpeg", ".png", ".gif" };
+    private const long MaxProfilePictureBytes = 5 * 1024 * 1024; // 5 MB
+
     private readonly UserManager<ApplicationUser> _userManager;
     private readonly ApplicationDbContext _context;
     private readonly IWebHostEnvironment _environment;
@@ -52,8 +59,31 @@ public class ProfileService : IProfileService
     {
         try
         {
-            var user = await _userManager.FindByIdAsync(userId) 
+            var user = await _userManager.FindByIdAsync(userId)
                 ?? throw new KeyNotFoundException($"User with ID {userId} not found.");
+
+            if (file == null || file.Length == 0)
+            {
+                return ServiceResult.Failure("No file was provided.");
+            }
+
+            if (file.Length > MaxProfilePictureBytes)
+            {
+                return ServiceResult.Failure("Profile picture must be 5 MB or smaller.");
+            }
+
+            var extension = Path.GetExtension(file.FileName).ToLowerInvariant();
+            if (!AllowedImageExtensions.Contains(extension))
+            {
+                return ServiceResult.Failure("Profile picture must be a JPG, PNG, or GIF image.");
+            }
+
+            // Verify the bytes actually match the declared image extension (block e.g. an
+            // .html/.svg payload renamed to .png that would be served as active content).
+            if (!await FileSignatureValidator.IsContentValidAsync(file, extension))
+            {
+                return ServiceResult.Failure("File content does not match its image extension.");
+            }
 
             // Create uploads directory if it doesn't exist
             var uploadsFolder = Path.Combine(_environment.WebRootPath, "uploads", "profile-pictures");

--- a/src/DocFlowHub.Infrastructure/Services/Storage/DocumentStorageService.cs
+++ b/src/DocFlowHub.Infrastructure/Services/Storage/DocumentStorageService.cs
@@ -85,6 +85,13 @@ public class DocumentStorageService : IDocumentStorageService
                 return ServiceResult<string>.Failure($"File type {extension} is not allowed");
             }
 
+            // Content sniffing: reject files whose bytes don't match the declared extension
+            // (e.g. an executable renamed to .pdf), so the whitelist can't be bypassed by rename.
+            if (!await FileSignatureValidator.IsContentValidAsync(file, extension))
+            {
+                return ServiceResult<string>.Failure($"File content does not match its {extension} extension");
+            }
+
             var blobName = GetBlobName(documentId, versionNumber);
             var blobClient = _containerClient.GetBlobClient(blobName);
 

--- a/src/DocFlowHub.Infrastructure/Services/Storage/FileSignatureValidator.cs
+++ b/src/DocFlowHub.Infrastructure/Services/Storage/FileSignatureValidator.cs
@@ -1,0 +1,108 @@
+using Microsoft.AspNetCore.Http;
+
+namespace DocFlowHub.Infrastructure.Services.Storage;
+
+/// <summary>
+/// Validates that an uploaded file's binary content matches its declared extension
+/// (magic-byte / signature sniffing). This closes the gap where the extension whitelist
+/// alone trusts the filename, so a mislabeled file (e.g. an executable renamed to .pdf)
+/// would otherwise reach storage. Extension and size limits are enforced separately by
+/// <see cref="DocumentStorageService"/>.
+/// </summary>
+public static class FileSignatureValidator
+{
+    private const int HeaderSampleSize = 16;
+
+    // Extensions with no reliable binary signature (plain text): accepted if the sampled
+    // header contains no NUL bytes (a cheap "this is really text, not a binary" heuristic).
+    private static readonly HashSet<string> TextExtensions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ".txt", ".md"
+    };
+
+    // Extension -> acceptable leading byte signatures. An extension matches if the header
+    // starts with any one of its candidate signatures.
+    private static readonly Dictionary<string, byte[][]> Signatures = new(StringComparer.OrdinalIgnoreCase)
+    {
+        [".pdf"]  = new[] { new byte[] { 0x25, 0x50, 0x44, 0x46 } },                          // "%PDF"
+        [".jpg"]  = new[] { new byte[] { 0xFF, 0xD8, 0xFF } },
+        [".jpeg"] = new[] { new byte[] { 0xFF, 0xD8, 0xFF } },
+        [".png"]  = new[] { new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A } },
+        [".gif"]  = new[] { new byte[] { 0x47, 0x49, 0x46, 0x38 } },                          // "GIF8"
+        // .docx (and modern Office) are ZIP containers; three standard ZIP record markers.
+        [".docx"] = new[]
+        {
+            new byte[] { 0x50, 0x4B, 0x03, 0x04 },
+            new byte[] { 0x50, 0x4B, 0x05, 0x06 },
+            new byte[] { 0x50, 0x4B, 0x07, 0x08 }
+        },
+        // legacy .doc is an OLE2 compound document.
+        [".doc"]  = new[] { new byte[] { 0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1 } }
+    };
+
+    /// <summary>
+    /// Returns true if the file's content is consistent with <paramref name="extension"/>.
+    /// Unknown (but whitelisted) extensions are not blocked here — the extension whitelist
+    /// remains the authority for which types are allowed at all.
+    /// </summary>
+    public static async Task<bool> IsContentValidAsync(IFormFile file, string extension)
+    {
+        var header = new byte[HeaderSampleSize];
+        int read;
+        await using (var stream = file.OpenReadStream())
+        {
+            read = await ReadAtLeastAsync(stream, header);
+        }
+
+        if (read == 0)
+        {
+            return false; // empty content
+        }
+
+        if (TextExtensions.Contains(extension))
+        {
+            for (var i = 0; i < read; i++)
+            {
+                if (header[i] == 0x00)
+                {
+                    return false; // NUL byte => not plain text
+                }
+            }
+            return true;
+        }
+
+        if (!Signatures.TryGetValue(extension, out var candidates))
+        {
+            return true; // no signature on record for this whitelisted extension
+        }
+
+        foreach (var signature in candidates)
+        {
+            if (read >= signature.Length && header.AsSpan(0, signature.Length).SequenceEqual(signature))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Reads up to <paramref name="buffer"/>.Length bytes, tolerating short reads from the
+    /// underlying stream (a single ReadAsync is not guaranteed to fill the buffer).
+    /// </summary>
+    private static async Task<int> ReadAtLeastAsync(Stream stream, byte[] buffer)
+    {
+        var total = 0;
+        while (total < buffer.Length)
+        {
+            var n = await stream.ReadAsync(buffer.AsMemory(total, buffer.Length - total));
+            if (n == 0)
+            {
+                break;
+            }
+            total += n;
+        }
+        return total;
+    }
+}

--- a/src/DocFlowHub.Infrastructure/Services/Storage/FileSignatureValidator.cs
+++ b/src/DocFlowHub.Infrastructure/Services/Storage/FileSignatureValidator.cs
@@ -61,11 +61,19 @@ public static class FileSignatureValidator
 
         if (TextExtensions.Contains(extension))
         {
+            // A byte-order mark marks a valid Unicode text encoding. UTF-16/UTF-32 text
+            // legitimately contains NUL bytes, so a recognized BOM is accepted outright —
+            // this matches TextExtractionService, which reads those encodings back.
+            if (HasTextBom(header, read))
+            {
+                return true;
+            }
+
             for (var i = 0; i < read; i++)
             {
                 if (header[i] == 0x00)
                 {
-                    return false; // NUL byte => not plain text
+                    return false; // NUL byte with no BOM => not plain text
                 }
             }
             return true;
@@ -85,6 +93,29 @@ public static class FileSignatureValidator
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// True if the header starts with a UTF-8, UTF-16, or UTF-32 byte-order mark.
+    /// (UTF-32 is checked before UTF-16 because the UTF-16 LE BOM is a prefix of it.)
+    /// </summary>
+    private static bool HasTextBom(byte[] header, int read)
+    {
+        bool StartsWith(params byte[] bom)
+        {
+            if (read < bom.Length) return false;
+            for (var i = 0; i < bom.Length; i++)
+            {
+                if (header[i] != bom[i]) return false;
+            }
+            return true;
+        }
+
+        return StartsWith(0x00, 0x00, 0xFE, 0xFF) // UTF-32 BE
+            || StartsWith(0xFF, 0xFE, 0x00, 0x00) // UTF-32 LE
+            || StartsWith(0xEF, 0xBB, 0xBF)        // UTF-8
+            || StartsWith(0xFE, 0xFF)              // UTF-16 BE
+            || StartsWith(0xFF, 0xFE);             // UTF-16 LE
     }
 
     /// <summary>

--- a/src/DocFlowHub.Web/Pages/Admin/Analytics.cshtml
+++ b/src/DocFlowHub.Web/Pages/Admin/Analytics.cshtml
@@ -5,10 +5,10 @@
     Layout = "_AdminLayout";
 }
 
-<div class="d-flex justify-content-between align-items-center mb-4">
+<div class="d-flex justify-content-between align-items-center admin-deep-header">
     <div>
-        <h1 class="h3 mb-1">AI Analytics & Monitoring</h1>
-        <p class="text-muted mb-0">System-wide AI usage monitoring and performance insights</p>
+        <h1>AI Analytics &amp; Monitoring</h1>
+        <p class="subtitle">System-wide AI usage monitoring and performance insights</p>
     </div>
     <div class="d-flex gap-2">
         <button type="button" class="btn btn-outline-secondary" onclick="refreshAnalytics()">

--- a/src/DocFlowHub.Web/Pages/Admin/UserLimits.cshtml
+++ b/src/DocFlowHub.Web/Pages/Admin/UserLimits.cshtml
@@ -6,10 +6,10 @@
     Layout = "_AdminLayout";
 }
 
-<div class="d-flex justify-content-between align-items-center mb-4">
+<div class="d-flex justify-content-between align-items-center admin-deep-header">
     <div>
-        <h1 class="h3 mb-1">User Rate Limits Management</h1>
-        <p class="text-muted mb-0">Monitor and manage AI usage limits for individual users</p>
+        <h1>User Rate Limits Management</h1>
+        <p class="subtitle">Monitor and manage AI usage limits for individual users</p>
     </div>
     <div class="d-flex gap-2">
         <button type="button" class="btn btn-outline-secondary" onclick="refreshLimits()">

--- a/src/DocFlowHub.Web/Pages/Admin/Users/Details.cshtml
+++ b/src/DocFlowHub.Web/Pages/Admin/Users/Details.cshtml
@@ -184,7 +184,7 @@ else
                         <div class="d-flex flex-column gap-2">
                             @foreach (var role in Model.UserDetail.Roles)
                             {
-                                <div class="d-flex justify-content-between align-items-center p-2 bg-light rounded">
+                                <div class="d-flex justify-content-between align-items-center p-2 rounded" style="background: var(--surface-secondary);">
                                     <div>
                                         <div class="fw-medium">@role</div>
                                         <small class="text-muted">Role permissions apply</small>

--- a/src/DocFlowHub.Web/Pages/Admin/Users/Index.cshtml
+++ b/src/DocFlowHub.Web/Pages/Admin/Users/Index.cshtml
@@ -37,16 +37,16 @@
         .security-score.medium { color: #ffc107; }
         .security-score.low { color: #dc3545; }
         .bulk-actions-panel {
-            background: #f8f9fa;
-            border: 1px solid #dee2e6;
+            background: var(--surface-secondary);
+            border: 1px solid var(--border-color);
             border-radius: 0.375rem;
             padding: 1rem;
             margin-bottom: 1rem;
             display: none;
         }
         .filter-panel {
-            background: #fff;
-            border: 1px solid #dee2e6;
+            background: var(--container-bg);
+            border: 1px solid var(--border-color);
             border-radius: 0.375rem;
             padding: 1rem;
             margin-bottom: 1rem;

--- a/src/DocFlowHub.Web/Pages/Admin/_AdminLayout.cshtml
+++ b/src/DocFlowHub.Web/Pages/Admin/_AdminLayout.cshtml
@@ -313,6 +313,88 @@
         font-weight: 600;
     }
 
+    /* ── Theme-aware overrides for legacy Bootstrap components on deep admin pages ──
+       These deep pages (Analytics, UserLimits, Roles/*, Users/*) still use raw Bootstrap
+       .card / .table / .form-control, which default to white and break in dark mode.
+       Swapping white → design tokens fixes dark mode; light mode is unchanged because the
+       tokens resolve to the same near-white/standard values Bootstrap would use. */
+    .card {
+        background: var(--container-bg);
+        border-color: var(--border-light);
+        color: var(--text-primary);
+    }
+
+    .card-header {
+        border-color: var(--border-light);
+        color: var(--text-primary);
+    }
+
+    .card-header.bg-transparent {
+        background-color: transparent !important;
+    }
+
+    .table {
+        --bs-table-color: var(--text-primary);
+        --bs-table-bg: transparent;
+        --bs-table-border-color: var(--border-light);
+        color: var(--text-primary);
+    }
+
+    .table > thead {
+        color: var(--text-secondary);
+    }
+
+    .list-group-item {
+        background: var(--container-bg);
+        border-color: var(--border-light);
+        color: var(--text-primary);
+    }
+
+    .form-control,
+    .form-select {
+        background-color: var(--surface-secondary);
+        border-color: var(--border-color);
+        color: var(--text-primary);
+    }
+
+    .form-control:focus,
+    .form-select:focus {
+        background-color: var(--surface-secondary);
+        color: var(--text-primary);
+        border-color: var(--accent-color);
+    }
+
+    .form-control::placeholder {
+        color: var(--text-muted);
+    }
+
+    /* Legacy bg-light PANELS (cards / plaintext fields) → token surface.
+       Note: bg-light badges keep their own light styling and are intentionally excluded. */
+    .card.bg-light,
+    .card-header.bg-light,
+    .form-control-plaintext.bg-light {
+        background-color: var(--surface-secondary) !important;
+        color: var(--text-primary);
+    }
+
+    /* Modern page header for deep admin pages (matches dashboard headings) */
+    .admin-deep-header {
+        margin-bottom: 24px;
+    }
+
+    .admin-deep-header h1 {
+        font-size: 28px;
+        font-weight: 700;
+        color: var(--text-primary);
+        margin-bottom: 4px;
+    }
+
+    .admin-deep-header .subtitle {
+        color: var(--text-secondary);
+        font-size: 15px;
+        margin-bottom: 0;
+    }
+
     /* Responsive */
     @@media (max-width: 1024px) {
         .admin-bottom-grid {

--- a/src/DocFlowHub.Web/Pages/Documents/Details.cshtml
+++ b/src/DocFlowHub.Web/Pages/Documents/Details.cshtml
@@ -841,15 +841,18 @@
             if (!modelSelect || !qualitySelect) return;
 
             function updateModelInfo() {
-                const selectedModel = modelSelect.value || 'gpt-4o-mini';
+                const selectedModel = modelSelect.value || 'claude-haiku-4-5';
                 const selectedQuality = qualitySelect.value || 'balanced';
 
                 // Update description
                 const descriptions = {
-                    'gpt-4.1': 'Most capable model - highest quality analysis',
+                    'gpt-4.1': 'Most capable GPT model - highest quality analysis',
                     'gpt-4.1-mini': 'Fast & efficient - high quality with good speed',
                     'gpt-4o': 'Advanced model - good balance of quality and cost',
-                    'gpt-4o-mini': 'Cost effective - good quality, lowest cost'
+                    'gpt-4o-mini': 'Cost effective - good quality, lowest cost',
+                    'claude-haiku-4-5': 'Fast & cost effective - great quality, lowest Claude cost',
+                    'claude-sonnet-5': 'Near-Opus quality - excellent balance of quality and cost',
+                    'claude-opus-4-8': 'Most capable Claude model - highest quality analysis'
                 };
 
                 const description = descriptions[selectedModel] || 'AI-powered version comparison';
@@ -860,7 +863,10 @@
                     'gpt-4.1': 0.020,
                     'gpt-4.1-mini': 0.008,
                     'gpt-4o': 0.015,
-                    'gpt-4o-mini': 0.005
+                    'gpt-4o-mini': 0.005,
+                    'claude-haiku-4-5': 0.004,
+                    'claude-sonnet-5': 0.010,
+                    'claude-opus-4-8': 0.018
                 };
 
                 const qualityMultipliers = {

--- a/src/DocFlowHub.Web/Pages/Documents/Details.cshtml
+++ b/src/DocFlowHub.Web/Pages/Documents/Details.cshtml
@@ -5,7 +5,7 @@
     ViewData["Title"] = Model.Document?.Title ?? "Document Details";
 }
 
-<div class="container-fluid">
+<div class="page-container page-transition">
     @if (!string.IsNullOrEmpty(Model.ErrorMessage))
     {
         <div class="alert alert-danger alert-dismissible fade show" role="alert">
@@ -27,53 +27,56 @@
     @if (Model.Document != null)
     {
         <!-- Breadcrumb Navigation with Team Context -->
-        <nav aria-label="breadcrumb" class="mb-4">
-            <ol class="breadcrumb">
-                <li class="breadcrumb-item"><a asp-page="/Index">Home</a></li>
+        <nav aria-label="breadcrumb">
+            <ol class="breadcrumb-modern">
+                <li><a asp-page="/Index">Home</a></li>
                 @if (Model.Document.TeamId.HasValue && !string.IsNullOrEmpty(Model.Document.TeamName))
                 {
-                    <li class="breadcrumb-item"><a asp-page="/Teams/Index">Teams</a></li>
-                    <li class="breadcrumb-item"><a asp-page="/Teams/Details" asp-route-id="@Model.Document.TeamId">@Model.Document.TeamName</a></li>
-                    <li class="breadcrumb-item"><a asp-page="./Index" asp-route-filter-teamid="@Model.Document.TeamId">Team Documents</a></li>
+                    <li class="breadcrumb-sep">/</li>
+                    <li><a asp-page="/Teams/Index">Teams</a></li>
+                    <li class="breadcrumb-sep">/</li>
+                    <li><a asp-page="/Teams/Details" asp-route-id="@Model.Document.TeamId">@Model.Document.TeamName</a></li>
+                    <li class="breadcrumb-sep">/</li>
+                    <li><a asp-page="./Index" asp-route-filter-teamid="@Model.Document.TeamId">Team Documents</a></li>
                 }
                 else
                 {
-                    <li class="breadcrumb-item"><a asp-page="./Index">Documents</a></li>
+                    <li class="breadcrumb-sep">/</li>
+                    <li><a asp-page="./Index">Documents</a></li>
                 }
-                <li class="breadcrumb-item active" aria-current="page">@Model.Document.Title</li>
+                <li class="breadcrumb-sep">/</li>
+                <li class="active" aria-current="page">@Model.Document.Title</li>
             </ol>
         </nav>
+
+        <!-- Page Header with actions -->
+        <div class="page-header d-flex justify-content-between align-items-center flex-wrap gap-2">
+            <div>
+                <h1 class="page-title"><div class="page-icon">📄</div> @Model.Document.Title</h1>
+            </div>
+            <div class="d-flex gap-2">
+                <form method="post" asp-page-handler="Download" asp-route-versionId="@Model.Document.CurrentVersionId" class="d-inline">
+                    <button type="submit" class="btn btn-success btn-sm">
+                        <i class="bi bi-download me-1"></i>Download
+                    </button>
+                </form>
+                @if (Model.Document.OwnerId == User.GetUserId())
+                {
+                    <a asp-page="./Edit" asp-route-id="@Model.Document.Id" class="btn btn-outline-primary btn-sm">
+                        <i class="bi bi-pencil me-1"></i>Edit
+                    </a>
+                    <button type="button" class="btn btn-outline-danger btn-sm"
+                            onclick="confirmDeleteDocument(@Model.Document.Id, @Html.Raw(Json.Serialize(Model.Document.Title)), '@FormatFileSize(Model.Document.FileSize)', '@Model.Document.CreatedAt.ToString("MMM dd, yyyy")')">
+                        <i class="bi bi-trash me-1"></i>Delete
+                    </button>
+                }
+            </div>
+        </div>
 
         <div class="row">
             <!-- Main Document Details -->
             <div class="col-lg-8">
-                <div class="card shadow-sm">
-                    <div class="card-header bg-primary text-white">
-                        <div class="d-flex justify-content-between align-items-center">
-                            <h1 class="card-title mb-0 h4">
-                                <i class="bi bi-file-earmark-text me-2"></i>
-                                @Model.Document.Title
-                            </h1>
-                            <div class="d-flex gap-2">
-                                <form method="post" asp-page-handler="Download" asp-route-versionId="@Model.Document.CurrentVersionId" class="d-inline">
-                                    <button type="submit" class="btn btn-success btn-sm">
-                                        <i class="bi bi-download me-1"></i>Download
-                                    </button>
-                                </form>
-                                @if (Model.Document.OwnerId == User.GetUserId())
-                                {
-                                    <a asp-page="./Edit" asp-route-id="@Model.Document.Id" class="btn btn-outline-light btn-sm">
-                                        <i class="bi bi-pencil me-1"></i>Edit
-                                    </a>
-                                    <button type="button" class="btn btn-outline-danger btn-sm" 
-                                            onclick="confirmDeleteDocument(@Model.Document.Id, @Html.Raw(Json.Serialize(Model.Document.Title)), '@FormatFileSize(Model.Document.FileSize)', '@Model.Document.CreatedAt.ToString("MMM dd, yyyy")')">
-                                        <i class="bi bi-trash me-1"></i>Delete
-                                    </button>
-                                }
-                            </div>
-                        </div>
-                    </div>
-                    <div class="card-body">
+                <div class="content-card">
                         @if (!string.IsNullOrEmpty(Model.Document.Description))
                         {
                             <div class="mb-4">
@@ -108,7 +111,7 @@
                                                 <h6 class="text-primary">
                                                     <i class="bi bi-key"></i> Key Points
                                                 </h6>
-                                                <div class="bg-light rounded p-3">
+                                                <div class="token-panel rounded p-3">
                                                     @{
                                                         var keyPoints = Model.Document.AISummary!.KeyPoints.Split('\n', StringSplitOptions.RemoveEmptyEntries);
                                                     }
@@ -279,25 +282,21 @@
                             </div>
                         }
                     </div>
-                </div>
 
                 @if (Model.ComparisonResult != null)
                 {
                     <!-- AI Version Comparison Results -->
-                    <div class="card shadow-sm mt-4">
-                        <div class="card-header bg-success text-white">
-                            <div class="d-flex justify-content-between align-items-center">
-                                <h5 class="card-title mb-0">
-                                    <i class="bi bi-magic"></i>
-                                    AI Version Comparison
-                                </h5>
-                                <div class="text-end">
-                                    <small>Generated by @Model.ComparisonResult.AIModel</small><br>
-                                    <small>Confidence: @(Math.Round((Model.ComparisonResult.ConfidenceScore ?? 0.8) * 100))%</small>
-                                </div>
+                    <div class="content-card mt-4">
+                        <div class="d-flex justify-content-between align-items-center mb-3">
+                            <h5 class="section-heading section-heading-success mb-0">
+                                <i class="bi bi-magic"></i> AI Version Comparison
+                            </h5>
+                            <div class="text-end text-muted small">
+                                <div>Generated by @Model.ComparisonResult.AIModel</div>
+                                <div>Confidence: @(Math.Round((Model.ComparisonResult.ConfidenceScore ?? 0.8) * 100))%</div>
                             </div>
                         </div>
-                        <div class="card-body">
+                        <div>
                             <div class="row">
                                 <div class="col-md-8">
                                     <!-- Change Summary -->
@@ -317,7 +316,7 @@
                                                 <i class="bi bi-list-ul"></i>
                                                 Detailed Changes
                                             </h6>
-                                            <div class="border rounded p-3 bg-light">
+                                            <div class="token-panel rounded p-3">
                                                 @{
                                                     var changes = Model.ComparisonResult.DetailedChanges.Split('\n', StringSplitOptions.RemoveEmptyEntries);
                                                 }
@@ -334,7 +333,7 @@
                                 </div>
                                 <div class="col-md-4">
                                     <!-- Analysis Metadata -->
-                                    <div class="bg-light rounded p-3">
+                                    <div class="token-panel rounded p-3">
                                         <h6 class="text-muted mb-3">Analysis Details</h6>
                                         
                                         <div class="mb-3">
@@ -398,24 +397,21 @@
             
             <!-- Version History Sidebar -->
             <div class="col-lg-4">
-                <div class="card shadow-sm">
-                    <div class="card-header">
-                        <h5 class="card-title mb-0">
-                            <i class="bi bi-clock-history"></i>
-                            Version History
-                        </h5>
+                <div class="content-card">
+                    <div class="d-flex flex-column mb-3">
+                        <h5 class="section-heading mb-1"><i class="bi bi-clock-history"></i> Version History</h5>
                         @if (Model.Versions.Items.Count() >= 2)
                         {
                             <small class="text-muted">Select versions to compare with AI analysis</small>
                         }
                     </div>
-                    <div class="card-body p-0">
+                    <div class="p-0">
                         @if (Model.Versions.Items.Any())
                         {
                             @if (Model.Versions.Items.Count() >= 2)
                             {
                                 <!-- Version Comparison Form -->
-                                <div class="p-3 border-bottom bg-light">
+                                <div class="p-3 border-bottom" style="background: var(--surface-secondary); border-radius: 10px;">
                                     <form method="post" asp-page-handler="CompareVersions">
                                         <div class="row g-2">
                                             <div class="col-6">
@@ -593,7 +589,7 @@
     }
     else
     {
-        <div class="text-center">
+        <div class="content-card text-center py-5">
             <h3>Document not found</h3>
             <p class="text-muted">The requested document could not be found or you don't have permission to view it.</p>
             <a asp-page="./Index" class="btn btn-primary">
@@ -732,6 +728,19 @@
         }
         return $"{number:n1} {suffixes[counter]}";
     }
+}
+
+@section Styles {
+<style>
+    .section-heading { display: flex; align-items: center; gap: 0.5rem; color: var(--text-primary); font-weight: 600; margin-bottom: 1.25rem; }
+    .section-heading i { color: var(--accent-color); }
+    .section-heading-success i { color: var(--success-color); }
+    .token-panel {
+        background: var(--surface-secondary) !important;
+        border: 1px solid var(--border-color);
+        color: var(--text-primary);
+    }
+</style>
 }
 
 @section Scripts {
@@ -893,8 +902,8 @@
         }
         
         .list-group-item-primary {
-            background-color: rgba(13, 110, 253, 0.1);
-            border-color: rgba(13, 110, 253, 0.2);
+            background-color: var(--surface-secondary);
+            border-color: var(--accent-color);
         }
     </style>
 } 

--- a/src/DocFlowHub.Web/Pages/Documents/Details.cshtml
+++ b/src/DocFlowHub.Web/Pages/Documents/Details.cshtml
@@ -732,9 +732,7 @@
 
 @section Styles {
 <style>
-    .section-heading { display: flex; align-items: center; gap: 0.5rem; color: var(--text-primary); font-weight: 600; margin-bottom: 1.25rem; }
-    .section-heading i { color: var(--accent-color); }
-    .section-heading-success i { color: var(--success-color); }
+    /* .section-heading / .section-heading-success live in components.css */
     .token-panel {
         background: var(--surface-secondary) !important;
         border: 1px solid var(--border-color);

--- a/src/DocFlowHub.Web/Pages/Documents/Details.cshtml.cs
+++ b/src/DocFlowHub.Web/Pages/Documents/Details.cshtml.cs
@@ -507,18 +507,10 @@ namespace DocFlowHub.Web.Pages.Documents
         /// </summary>
         private AIModel GetSelectedAIModel()
         {
-            // If user explicitly selected a model, use that
+            // If user explicitly selected a model, use that (Claude + GPT both supported)
             if (!string.IsNullOrEmpty(ComparisonAIModel))
             {
-                return ComparisonAIModel.ToLower() switch
-                {
-                    "gpt-4o" => AIModel.Gpt4o,
-                    "gpt-4o-mini" => AIModel.Gpt4oMini,
-                    "gpt-4-turbo" => AIModel.Gpt4o, // Map turbo to 4o for now
-                    "gpt-4.1" => AIModel.Gpt41,
-                    "gpt-4.1-mini" => AIModel.Gpt41Mini,
-                    _ => GetUserPreferredModel()
-                };
+                return AIModelHelper.FromApiString(ComparisonAIModel);
             }
 
             return GetUserPreferredModel();
@@ -530,7 +522,7 @@ namespace DocFlowHub.Web.Pages.Documents
         private AIModel GetUserPreferredModel()
         {
             // PreferredModel is already an AIModel enum, so just return it directly
-            return UserAISettings?.PreferredModel ?? AIModel.Gpt4oMini;
+            return UserAISettings?.PreferredModel ?? AIModelHelper.GetDefaultModel();
         }
 
         /// <summary>
@@ -538,7 +530,7 @@ namespace DocFlowHub.Web.Pages.Documents
         /// </summary>
         public string GetPreferredModelDisplay()
         {
-            var preferredModel = UserAISettings?.PreferredModel ?? AIModel.Gpt4oMini;
+            var preferredModel = UserAISettings?.PreferredModel ?? AIModelHelper.GetDefaultModel();
             return preferredModel switch
             {
                 AIModel.Gpt41 => "gpt-4.1",

--- a/src/DocFlowHub.Web/Pages/Documents/Details.cshtml.cs
+++ b/src/DocFlowHub.Web/Pages/Documents/Details.cshtml.cs
@@ -425,14 +425,7 @@ namespace DocFlowHub.Web.Pages.Documents
                 if (comparisonResult.Succeeded && comparisonResult.Data != null)
                 {
                     ComparisonResult = comparisonResult.Data;
-                    var modelDisplayName = aiModel switch
-                    {
-                        AIModel.Gpt41 => "GPT-4.1",
-                        AIModel.Gpt41Mini => "GPT-4.1 Mini", 
-                        AIModel.Gpt4o => "GPT-4o",
-                        AIModel.Gpt4oMini => "GPT-4o Mini",
-                        _ => "GPT-4o Mini"
-                    };
+                    var modelDisplayName = aiModel.ToDisplayName();
                     SuccessMessage = $"Successfully compared version {fromVersion} to version {toVersion} using {modelDisplayName}";
                 }
                 else
@@ -531,14 +524,7 @@ namespace DocFlowHub.Web.Pages.Documents
         public string GetPreferredModelDisplay()
         {
             var preferredModel = UserAISettings?.PreferredModel ?? AIModelHelper.GetDefaultModel();
-            return preferredModel switch
-            {
-                AIModel.Gpt41 => "gpt-4.1",
-                AIModel.Gpt41Mini => "gpt-4.1-mini",
-                AIModel.Gpt4o => "gpt-4o",
-                AIModel.Gpt4oMini => "gpt-4o-mini",
-                _ => "gpt-4o-mini"
-            };
+            return preferredModel.ToApiString();
         }
     }
 } 

--- a/src/DocFlowHub.Web/Pages/Documents/Edit.cshtml
+++ b/src/DocFlowHub.Web/Pages/Documents/Edit.cshtml
@@ -4,19 +4,28 @@
     ViewData["Title"] = $"Edit - {Model.Document?.Title ?? "Document"}";
 }
 
-<div class="container-fluid">
-    <!-- Breadcrumb Navigation -->
-    <nav aria-label="breadcrumb" class="mb-4">
-        <ol class="breadcrumb">
-            <li class="breadcrumb-item"><a asp-page="/Index">Home</a></li>
-            <li class="breadcrumb-item"><a asp-page="./Index">Documents</a></li>
+<div class="page-container page-transition">
+    <!-- Breadcrumb -->
+    <nav aria-label="breadcrumb">
+        <ol class="breadcrumb-modern">
+            <li><a asp-page="/Index">Home</a></li>
+            <li class="breadcrumb-sep">/</li>
+            <li><a asp-page="./Index">Documents</a></li>
             @if (Model.Document != null)
             {
-                <li class="breadcrumb-item"><a asp-page="./Details" asp-route-id="@Model.Document.Id">@Model.Document.Title</a></li>
+                <li class="breadcrumb-sep">/</li>
+                <li><a asp-page="./Details" asp-route-id="@Model.Document.Id">@Model.Document.Title</a></li>
             }
-            <li class="breadcrumb-item active" aria-current="page">Edit</li>
+            <li class="breadcrumb-sep">/</li>
+            <li class="active" aria-current="page">Edit</li>
         </ol>
     </nav>
+
+    <!-- Page Header -->
+    <div class="page-header">
+        <h1 class="page-title"><div class="page-icon">✏️</div> Edit Document</h1>
+        <p class="page-subtitle">Update document information or upload a new version</p>
+    </div>
 
     @if (!string.IsNullOrEmpty(Model.ErrorMessage))
     {
@@ -39,15 +48,9 @@
         <div class="row">
             <!-- Document Metadata Edit -->
             <div class="col-lg-8">
-                <div class="card shadow-sm mb-4">
-                    <div class="card-header bg-primary text-white">
-                        <h4 class="card-title mb-0">
-                            <i class="bi bi-pencil-square"></i>
-                            Edit Document Information
-                        </h4>
-                    </div>
-                    <div class="card-body">
-                        <form method="post" asp-page-handler="UpdateMetadata">
+                <div class="form-card mb-4">
+                    <h5 class="section-heading"><i class="bi bi-pencil-square"></i> Edit Document Information</h5>
+                    <form method="post" asp-page-handler="UpdateMetadata">
                             <div class="row">
                                 <div class="col-md-8">
                                     <div class="mb-3">
@@ -66,19 +69,17 @@
                                 <div class="col-md-4">
                                     <div class="mb-3">
                                         <label class="form-label">Current File Info</label>
-                                        <div class="card">
-                                            <div class="card-body p-3">
-                                                <p class="mb-1">
-                                                    <strong>Type:</strong> 
-                                                    <span class="badge bg-info">@Model.Document.FileType.ToUpper()</span>
-                                                </p>
-                                                <p class="mb-1">
-                                                    <strong>Size:</strong> @FormatFileSize(Model.Document.FileSize)
-                                                </p>
-                                                <p class="mb-0">
-                                                    <strong>Modified:</strong> @((Model.Document.UpdatedAt ?? Model.Document.CreatedAt).ToString("MMM dd, yyyy"))
-                                                </p>
-                                            </div>
+                                        <div class="info-panel">
+                                            <p class="mb-1">
+                                                <strong>Type:</strong>
+                                                <span class="badge bg-info">@Model.Document.FileType.ToUpper()</span>
+                                            </p>
+                                            <p class="mb-1">
+                                                <strong>Size:</strong> @FormatFileSize(Model.Document.FileSize)
+                                            </p>
+                                            <p class="mb-0">
+                                                <strong>Modified:</strong> @((Model.Document.UpdatedAt ?? Model.Document.CreatedAt).ToString("MMM dd, yyyy"))
+                                            </p>
                                         </div>
                                     </div>
                                 </div>
@@ -127,18 +128,11 @@
                                 </div>
                             </div>
                         </form>
-                    </div>
                 </div>
 
                 <!-- Upload New Version -->
-                <div class="card shadow-sm">
-                    <div class="card-header bg-success text-white">
-                        <h4 class="card-title mb-0">
-                            <i class="bi bi-cloud-upload"></i>
-                            Upload New Version
-                        </h4>
-                    </div>
-                    <div class="card-body">
+                <div class="form-card">
+                    <h5 class="section-heading section-heading-success"><i class="bi bi-cloud-upload"></i> Upload New Version</h5>
                         <form method="post" asp-page-handler="UploadNewVersion" enctype="multipart/form-data">
                             <div class="mb-3">
                                 <label asp-for="NewVersionFile" class="form-label">Select New File *</label>
@@ -166,20 +160,13 @@
                                 </small>
                             </div>
                         </form>
-                    </div>
                 </div>
             </div>
 
             <!-- Sidebar with Current Categories and Version Info -->
             <div class="col-lg-4">
-                <div class="card shadow-sm mb-4">
-                    <div class="card-header">
-                        <h5 class="card-title mb-0">
-                            <i class="bi bi-tags"></i>
-                            Current Categories
-                        </h5>
-                    </div>
-                    <div class="card-body">
+                <div class="content-card mb-4">
+                    <h5 class="section-heading"><i class="bi bi-tags"></i> Current Categories</h5>
                         @if (Model.CurrentCategories.Any())
                         {
                             <div class="d-flex flex-wrap gap-2">
@@ -196,17 +183,10 @@
                         {
                             <p class="text-muted mb-0">No categories assigned</p>
                         }
-                    </div>
                 </div>
 
-                <div class="card shadow-sm">
-                    <div class="card-header">
-                        <h5 class="card-title mb-0">
-                            <i class="bi bi-info-circle"></i>
-                            Document Information
-                        </h5>
-                    </div>
-                    <div class="card-body">
+                <div class="content-card">
+                    <h5 class="section-heading"><i class="bi bi-info-circle"></i> Document Information</h5>
                         <dl class="row">
                             <dt class="col-sm-5">Created</dt>
                             <dd class="col-sm-7">@Model.Document.CreatedAt.ToString("MMM dd, yyyy")</dd>
@@ -232,14 +212,13 @@
                                 <i class="bi bi-eye"></i> View Details & History
                             </a>
                         </div>
-                    </div>
                 </div>
             </div>
         </div>
     }
     else
     {
-        <div class="text-center">
+        <div class="content-card text-center py-5">
             <h3>Document not found</h3>
             <p class="text-muted">The requested document could not be found or you don't have permission to edit it.</p>
             <a asp-page="./Index" class="btn btn-primary">
@@ -264,9 +243,22 @@
     }
 }
 
+@section Styles {
+<style>
+    .section-heading { display: flex; align-items: center; gap: 0.5rem; color: var(--text-primary); font-weight: 600; margin-bottom: 1.25rem; }
+    .section-heading i { color: var(--accent-color); }
+    .section-heading-success i { color: var(--success-color); }
+    .info-panel {
+        border: 1px solid var(--border-color); border-radius: 10px;
+        background: var(--surface-secondary); padding: 0.85rem 1rem; color: var(--text-primary);
+    }
+    .info-panel p { color: var(--text-primary); }
+</style>
+}
+
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />
-    
+
     <script>
         // File upload validation
         document.querySelector('input[type="file"]').addEventListener('change', function(e) {

--- a/src/DocFlowHub.Web/Pages/Documents/Edit.cshtml
+++ b/src/DocFlowHub.Web/Pages/Documents/Edit.cshtml
@@ -245,9 +245,7 @@
 
 @section Styles {
 <style>
-    .section-heading { display: flex; align-items: center; gap: 0.5rem; color: var(--text-primary); font-weight: 600; margin-bottom: 1.25rem; }
-    .section-heading i { color: var(--accent-color); }
-    .section-heading-success i { color: var(--success-color); }
+    /* .section-heading / .section-heading-success live in components.css */
     .info-panel {
         border: 1px solid var(--border-color); border-radius: 10px;
         background: var(--surface-secondary); padding: 0.85rem 1rem; color: var(--text-primary);

--- a/src/DocFlowHub.Web/Pages/Documents/Upload.cshtml
+++ b/src/DocFlowHub.Web/Pages/Documents/Upload.cshtml
@@ -607,7 +607,7 @@
                     return;
                 }
 
-                const selectedModel = modelSelect ? modelSelect.value : 'Gpt4oMini';
+                const selectedModel = modelSelect ? modelSelect.value : 'ClaudeHaiku45';
                 const quality = qualitySlider ? parseFloat(qualitySlider.value) : 0.7;
 
                 // Calculate real-time estimates
@@ -653,7 +653,10 @@
                     'Gpt4oMini': 0.00015 / 1000,
                     'Gpt4o': 0.005 / 1000,
                     'Gpt41Mini': 0.003 / 1000,
-                    'Gpt41': 0.01 / 1000
+                    'Gpt41': 0.01 / 1000,
+                    'ClaudeHaiku45': 0.001 / 1000,
+                    'ClaudeSonnet5': 0.003 / 1000,
+                    'ClaudeOpus48': 0.005 / 1000
                 };
                 return costs[model] || 0.001 / 1000;
             };
@@ -663,7 +666,10 @@
                     'Gpt4oMini': 8,
                     'Gpt4o': 12,
                     'Gpt41Mini': 18,
-                    'Gpt41': 25
+                    'Gpt41': 25,
+                    'ClaudeHaiku45': 6,
+                    'ClaudeSonnet5': 12,
+                    'ClaudeOpus48': 20
                 };
                 return times[model] || 15;
             };
@@ -673,7 +679,10 @@
                     'Gpt4oMini': 'Fast, cost-effective, good for basic summaries',
                     'Gpt4o': 'Balanced speed and quality, excellent for most documents',
                     'Gpt41Mini': 'High quality analysis, ideal for important documents',
-                    'Gpt41': 'Highest quality insights, best for complex or critical content'
+                    'Gpt41': 'Highest quality insights, best for complex or critical content',
+                    'ClaudeHaiku45': 'Fast and cost-effective Claude model, great for summaries',
+                    'ClaudeSonnet5': 'Near-Opus quality, excellent for most documents',
+                    'ClaudeOpus48': 'Most capable Claude model, best for complex or critical content'
                 };
                 return capabilities[model] || 'AI-powered document analysis';
             };
@@ -875,7 +884,7 @@
 
             // Process AI stages with realistic timing
             const processAIStages = async (selectedModel, quality) => {
-                const baseTime = getBaseProcessingTime(selectedModel || 'Gpt4oMini');
+                const baseTime = getBaseProcessingTime(selectedModel || 'ClaudeHaiku45');
                 const qualityMultiplier = quality <= 0.3 ? 0.7 : quality <= 0.7 ? 1.0 : 1.4;
                 
                 for (let i = 0; i < aiStages.length; i++) {
@@ -963,7 +972,7 @@
                 const qualitySlider = document.getElementById('quality-slider');
                 
                 const aiEnabled = aiToggle && aiToggle.checked;
-                const selectedModel = modelSelect ? modelSelect.value : 'Gpt4oMini';
+                const selectedModel = modelSelect ? modelSelect.value : 'ClaudeHaiku45';
                 const quality = qualitySlider ? parseFloat(qualitySlider.value) : 0.7;
                 
                 showUploadProgress();

--- a/src/DocFlowHub.Web/Pages/Documents/Upload.cshtml
+++ b/src/DocFlowHub.Web/Pages/Documents/Upload.cshtml
@@ -5,26 +5,27 @@
     ViewData["Title"] = "Upload Document";
 }
 
-<div class="container page-transition">
-    <!-- Enhanced Breadcrumb -->
-    <nav aria-label="breadcrumb" class="mb-4">
-        <ol class="breadcrumb">
-            <li class="breadcrumb-item"><a asp-page="/Index">Home</a></li>
-            <li class="breadcrumb-item"><a asp-page="./Index">Documents</a></li>
-            <li class="breadcrumb-item active" aria-current="page">Upload</li>
+<div class="page-container page-transition">
+    <!-- Breadcrumb -->
+    <nav aria-label="breadcrumb">
+        <ol class="breadcrumb-modern">
+            <li><a asp-page="/Index">Home</a></li>
+            <li class="breadcrumb-sep">/</li>
+            <li><a asp-page="./Index">Documents</a></li>
+            <li class="breadcrumb-sep">/</li>
+            <li class="active" aria-current="page">Upload</li>
         </ol>
     </nav>
 
+    <!-- Page Header -->
+    <div class="page-header">
+        <h1 class="page-title"><div class="page-icon">☁️</div> Upload Document</h1>
+        <p class="page-subtitle">Add a new document and optionally generate an AI summary</p>
+    </div>
+
     <div class="row justify-content-center">
         <div class="col-lg-8">
-            <div class="card shadow-sm">
-                <div class="card-header bg-primary text-white">
-                    <h1 class="card-title mb-0 h4">
-                        <i class="bi bi-cloud-upload me-2"></i>
-                        Upload Document
-                    </h1>
-                </div>
-                <div class="card-body">
+            <div class="form-card">
                     @if (!string.IsNullOrEmpty(Model.ErrorMessage))
                     {
                         <div class="alert alert-danger alert-dismissible fade show" role="alert">
@@ -401,7 +402,6 @@
                             </button>
                         </div>
                     </form>
-                </div>
             </div>
         </div>
     </div>
@@ -1203,9 +1203,9 @@
         align-items: center;
         justify-content: center;
         margin: 0 auto;
-        border: 2px solid #dee2e6;
-        background: #f8f9fa;
-        color: #6c757d;
+        border: 2px solid var(--border-color);
+        background: var(--surface-secondary);
+        color: var(--text-secondary);
         transition: all 0.3s ease;
     }
 
@@ -1216,14 +1216,14 @@
     .step-label {
         display: block;
         margin-top: 0.5rem;
-        color: #6c757d;
+        color: var(--text-secondary);
         font-weight: 500;
     }
 
     .step-line {
         flex: 1;
         height: 2px;
-        background: #dee2e6;
+        background: var(--border-color);
         margin: 0 1rem;
         align-self: center;
         margin-top: -20px;
@@ -1232,28 +1232,28 @@
 
     /* Step States */
     .step-item.active .step-icon {
-        border-color: #0d6efd;
-        background: #0d6efd;
+        border-color: var(--accent-color);
+        background: var(--accent-color);
         color: white;
     }
 
     .step-item.active .step-label {
-        color: #0d6efd;
+        color: var(--accent-color);
         font-weight: 600;
     }
 
     .step-item.completed .step-icon {
-        border-color: #198754;
-        background: #198754;
+        border-color: var(--success-color);
+        background: var(--success-color);
         color: white;
     }
 
     .step-item.completed .step-label {
-        color: #198754;
+        color: var(--success-color);
     }
 
     .step-line.completed {
-        background: #198754;
+        background: var(--success-color);
     }
 
     /* AI Processing Animations */
@@ -1274,10 +1274,10 @@
 
     /* Progress Enhancements */
     .upload-progress {
-        border: 1px solid #e3f2fd;
+        border: 1px solid var(--border-color);
         border-radius: 0.5rem;
         padding: 1rem;
-        background: #fafafa;
+        background: var(--surface-secondary);
         display: none;
     }
 
@@ -1290,7 +1290,7 @@
     }
 
     .progress-message i {
-        color: #0d6efd;
+        color: var(--accent-color);
     }
 
     /* AI Stage Specific Colors */
@@ -1316,39 +1316,37 @@
     .file-upload-container {
         cursor: pointer;
         transition: all 0.3s ease;
-        border: 2px dashed #dee2e6;
+        border: 2px dashed var(--border-color);
         border-radius: 8px;
         padding: 2rem;
         text-align: center;
-        background: #f8f9fa;
+        background: var(--surface-secondary);
     }
 
     .file-upload-container:hover {
-        border-color: #007bff;
-        background: #e3f2fd;
+        border-color: var(--accent-color);
+        background: var(--surface-hover, var(--surface-secondary));
     }
 
     .file-upload-container.dragover {
-        border-color: #28a745;
-        background: #d4edda;
+        border-color: var(--success-color);
+        background: rgba(16, 185, 129, 0.12);
         transform: scale(1.02);
     }
 
     /* File input success/error states */
     .field-success {
-        border-color: #28a745 !important;
-        background-color: #f8fff9;
+        border-color: var(--success-color) !important;
+        background-color: rgba(16, 185, 129, 0.08);
     }
 
     .field-error {
-        border-color: #dc3545 !important;
-        background-color: #fff5f5;
+        border-color: var(--error-color) !important;
+        background-color: rgba(239, 68, 68, 0.08);
     }
 
     /* Selected file display */
     .selected-file .alert {
         margin-bottom: 0;
-        border: 1px solid #b6d7ff;
-        background: #e3f2fd;
     }
 </style> 

--- a/src/DocFlowHub.Web/Pages/Documents/Upload.cshtml
+++ b/src/DocFlowHub.Web/Pages/Documents/Upload.cshtml
@@ -62,7 +62,9 @@
                                     <small class="text-muted">
                                         <i class="bi bi-info-circle me-1"></i>
                                         Maximum file size: 30MB<br>
-                                        Supported formats: PDF, DOC, DOCX, TXT, MD, JPG, PNG, GIF
+                                        Supported formats: PDF, DOC, DOCX, TXT, MD, JPG, PNG, GIF<br>
+                                        <i class="bi bi-lightbulb me-1"></i>
+                                        Legacy <strong>.doc</strong> files can't be read for AI summaries — re-save as <strong>.docx</strong> for automatic summarization.
                                     </small>
                                 </div>
                             </div>

--- a/src/DocFlowHub.Web/Pages/Documents/Upload.cshtml.cs
+++ b/src/DocFlowHub.Web/Pages/Documents/Upload.cshtml.cs
@@ -75,7 +75,7 @@ public class UploadModel : PageModel
 
     [BindProperty]
     [Display(Name = "AI Model")]
-    public AIModel SelectedAIModel { get; set; } = AIModel.Gpt4oMini;
+    public AIModel SelectedAIModel { get; set; } = AIModelHelper.GetDefaultModel();
 
     [BindProperty]
     [Display(Name = "AI Quality")]
@@ -388,7 +388,7 @@ public class UploadModel : PageModel
     private void SetFallbackDefaults()
     {
         GenerateAISummary = true; // Default to enabled (will be overridden if AI features disabled)
-        SelectedAIModel = AIModel.Gpt4oMini; // Most cost-effective option
+        SelectedAIModel = AIModelHelper.GetDefaultModel(); // Claude Haiku 4.5 — most cost-effective
         AIQuality = 0.7; // Balanced quality setting
     }
 
@@ -400,7 +400,7 @@ public class UploadModel : PageModel
                 Model = model,
                 Name = model.ToDisplayName(),
                 Description = model.GetCostDescription(),
-                IsRecommended = model == AIModel.Gpt4oMini || model == AIModel.Gpt4o
+                IsRecommended = model == AIModel.ClaudeHaiku45 || model == AIModel.ClaudeSonnet5
             })
             .ToList();
     }
@@ -471,6 +471,9 @@ public class UploadModel : PageModel
             AIModel.Gpt4o => "Balanced speed and quality, excellent for most documents",
             AIModel.Gpt41Mini => "High quality analysis, ideal for important documents",
             AIModel.Gpt41 => "Highest quality insights, best for complex or critical content",
+            AIModel.ClaudeHaiku45 => "Fast and cost-effective Claude model, great for summaries",
+            AIModel.ClaudeSonnet5 => "Near-Opus quality, excellent for most documents",
+            AIModel.ClaudeOpus48 => "Most capable Claude model, best for complex or critical content",
             _ => "AI-powered document analysis"
         };
     }
@@ -488,11 +491,14 @@ public class UploadModel : PageModel
         // These would ideally come from a configuration or real-time pricing API
         return model switch
         {
-            AIModel.Gpt4oMini => 0.00015 / 1000, // $0.15 per 1M tokens
-            AIModel.Gpt4o => 0.005 / 1000,       // $5.00 per 1M tokens
-            AIModel.Gpt41Mini => 0.003 / 1000,   // $3.00 per 1M tokens
-            AIModel.Gpt41 => 0.01 / 1000,        // $10.00 per 1M tokens
-            _ => 0.001 / 1000                     // Default fallback
+            AIModel.Gpt4oMini => 0.00015 / 1000,     // $0.15 per 1M tokens
+            AIModel.Gpt4o => 0.005 / 1000,           // $5.00 per 1M tokens
+            AIModel.Gpt41Mini => 0.003 / 1000,       // $3.00 per 1M tokens
+            AIModel.Gpt41 => 0.01 / 1000,            // $10.00 per 1M tokens
+            AIModel.ClaudeHaiku45 => 0.001 / 1000,   // $1.00 per 1M input tokens
+            AIModel.ClaudeSonnet5 => 0.003 / 1000,   // $3.00 per 1M input tokens
+            AIModel.ClaudeOpus48 => 0.005 / 1000,    // $5.00 per 1M input tokens
+            _ => 0.001 / 1000                         // Default fallback
         };
     }
 
@@ -501,11 +507,14 @@ public class UploadModel : PageModel
         // Estimated base processing time in seconds
         return model switch
         {
-            AIModel.Gpt4oMini => 8,   // Fast model
-            AIModel.Gpt4o => 12,      // Balanced model
-            AIModel.Gpt41Mini => 18,  // Higher quality, slower
-            AIModel.Gpt41 => 25,      // Highest quality, slowest
-            _ => 15                   // Default
+            AIModel.Gpt4oMini => 8,        // Fast model
+            AIModel.Gpt4o => 12,           // Balanced model
+            AIModel.Gpt41Mini => 18,       // Higher quality, slower
+            AIModel.Gpt41 => 25,           // Highest quality, slowest
+            AIModel.ClaudeHaiku45 => 6,    // Fastest Claude model
+            AIModel.ClaudeSonnet5 => 12,   // Balanced Claude model
+            AIModel.ClaudeOpus48 => 20,    // Most capable, slower
+            _ => 15                        // Default
         };
     }
 

--- a/src/DocFlowHub.Web/Pages/Folders/Create.cshtml
+++ b/src/DocFlowHub.Web/Pages/Folders/Create.cshtml
@@ -139,15 +139,7 @@
 
 @section Styles {
 <style>
-    .section-heading { display: flex; align-items: center; gap: 0.5rem; color: var(--text-primary); font-weight: 600; margin-bottom: 1.25rem; }
-    .section-heading i { color: var(--accent-color); }
-    .parent-picker {
-        border: 1px solid var(--border-color); border-radius: 10px;
-        background: var(--surface-secondary); padding: 0.85rem 1rem; min-height: 120px;
-    }
-    .parent-picker .form-check { margin-bottom: 0.5rem; }
-    .parent-picker .form-check-label { cursor: pointer; padding-left: 0.25rem; color: var(--text-primary); }
-    .parent-picker .form-check-input:checked + .form-check-label { font-weight: 600; color: var(--accent-color); }
+    /* .section-heading and .parent-picker live in components.css */
     .folder-preview { padding: 1rem; border: 1px solid var(--border-color); border-radius: 10px; background: var(--surface-secondary); color: var(--text-primary); }
 </style>
 }

--- a/src/DocFlowHub.Web/Pages/Folders/Create.cshtml
+++ b/src/DocFlowHub.Web/Pages/Folders/Create.cshtml
@@ -4,195 +4,131 @@
     ViewData["Title"] = "Create Folder";
 }
 
-<div class="container-fluid">
-    <!-- Breadcrumb Navigation -->
-    <nav aria-label="breadcrumb" class="mb-4">
-        <ol class="breadcrumb">
-            <li class="breadcrumb-item">
-                <a asp-page="/Index" class="text-decoration-none">
-                    <i class="bi bi-house-door me-1"></i>Home
-                </a>
-            </li>
-            <li class="breadcrumb-item">
-                <a asp-page="/Projects/Index" class="text-decoration-none">
-                    <i class="bi bi-kanban me-1"></i>Projects
-                </a>
-            </li>
+<div class="page-container page-transition">
+    <!-- Breadcrumb -->
+    <nav aria-label="breadcrumb">
+        <ol class="breadcrumb-modern">
+            <li><a asp-page="/Index">Home</a></li>
+            <li class="breadcrumb-sep">/</li>
+            <li><a asp-page="/Projects/Index">Projects</a></li>
             @if (Model.Project != null)
             {
-                <li class="breadcrumb-item">
-                    <a asp-page="/Projects/Details" asp-route-id="@Model.Project.Id" class="text-decoration-none">
-                        <i class="bi bi-@Model.Project.Icon me-1"></i>@Model.Project.Name
-                    </a>
-                </li>
-                <li class="breadcrumb-item">
-                    <a asp-page="/Folders/Index" asp-route-projectId="@Model.Project.Id" class="text-decoration-none">
-                        <i class="bi bi-folder me-1"></i>Folders
-                    </a>
-                </li>
+                <li class="breadcrumb-sep">/</li>
+                <li><a asp-page="/Projects/Details" asp-route-id="@Model.Project.Id">@Model.Project.Name</a></li>
+                <li class="breadcrumb-sep">/</li>
+                <li><a asp-page="/Folders/Index" asp-route-projectId="@Model.Project.Id">Folders</a></li>
             }
-            <li class="breadcrumb-item active" aria-current="page">
-                <i class="bi bi-plus-circle me-1"></i>Create Folder
-            </li>
+            <li class="breadcrumb-sep">/</li>
+            <li class="active" aria-current="page">Create Folder</li>
         </ol>
     </nav>
 
     <!-- Page Header -->
-    <div class="d-flex justify-content-between align-items-center mb-4">
+    <div class="page-header d-flex justify-content-between align-items-center flex-wrap gap-2">
         <div>
-            <h1 class="h3 mb-1">
-                <i class="bi bi-folder-plus me-2"></i>Create New Folder
-            </h1>
+            <h1 class="page-title"><div class="page-icon">📂</div> Create New Folder</h1>
             @if (Model.Project != null)
             {
-                <p class="text-muted mb-0">
-                    Creating folder in <strong>@Model.Project.Name</strong>
-                </p>
+                <p class="page-subtitle">Creating folder in <strong>@Model.Project.Name</strong></p>
             }
         </div>
-        <div>
-            <a asp-page="/Folders/Index" asp-route-projectId="@Model.ProjectId" 
-               class="btn btn-outline-secondary">
-                <i class="bi bi-arrow-left me-1"></i>Back to Folders
-            </a>
-        </div>
+        <a asp-page="/Folders/Index" asp-route-projectId="@Model.ProjectId" class="cancel-btn">
+            <i class="bi bi-arrow-left"></i> Back to Folders
+        </a>
     </div>
 
-    <div class="row">
+    <div class="row g-4">
         <div class="col-lg-8">
-            <!-- Create Folder Form -->
-            <div class="card">
-                <div class="card-header">
-                    <h5 class="mb-0">
-                        <i class="bi bi-folder me-2"></i>Folder Details
-                    </h5>
-                </div>
-                <div class="card-body">
-                    <form method="post" id="createFolderForm">
-                        <input type="hidden" asp-for="ProjectId" />
-                        <input type="hidden" asp-for="ParentFolderId" />
-                        
-                        <div class="mb-3">
-                            <label asp-for="Name" class="form-label">Folder Name <span class="text-danger">*</span></label>
-                            <input asp-for="Name" class="form-control" placeholder="Enter folder name..." 
-                                   maxlength="100" required />
-                            <div class="form-text">
-                                Choose a descriptive name for your folder (max 100 characters).
-                            </div>
-                            <span asp-validation-for="Name" class="text-danger"></span>
-                        </div>
+            <div class="form-card">
+                <h5 class="section-heading"><i class="bi bi-folder"></i> Folder Details</h5>
+                <form method="post" id="createFolderForm">
+                    <input type="hidden" asp-for="ProjectId" />
+                    <input type="hidden" asp-for="ParentFolderId" />
 
-                        <div class="mb-3">
-                            <label asp-for="Description" class="form-label">Description</label>
-                            <textarea asp-for="Description" class="form-control" rows="3" 
-                                      placeholder="Optional description of this folder..." 
-                                      maxlength="500"></textarea>
-                            <div class="form-text">
-                                Provide additional context about this folder (max 500 characters).
-                            </div>
-                            <span asp-validation-for="Description" class="text-danger"></span>
-                        </div>
+                    <div class="form-group full-width">
+                        <label asp-for="Name" class="form-label"><i class="bi bi-card-text"></i> Folder Name *</label>
+                        <input asp-for="Name" class="form-input" placeholder="Enter folder name..." maxlength="100" required />
+                        <span asp-validation-for="Name" class="validation-message"></span>
+                        <div class="form-hint">Choose a descriptive name for your folder (max 100 characters).</div>
+                    </div>
 
-                        @if (Model.AvailableParentFolders.Any())
-                        {
-                            <div class="mb-3">
-                                <label class="form-label">Parent Folder</label>
-                                <div class="form-control" style="height: auto; min-height: 120px;">
-                                    <div class="mb-2">
-                                        <div class="form-check">
-                                            <input class="form-check-input" type="radio" name="parentFolderSelection" 
-                                                   id="noParent" value="none" 
-                                                   @(Model.ParentFolderId == null ? "checked" : "") />
-                                            <label class="form-check-label" for="noParent">
-                                                <i class="bi bi-folder me-1"></i>Create at root level
-                                            </label>
-                                        </div>
+                    <div class="form-group full-width">
+                        <label asp-for="Description" class="form-label"><i class="bi bi-card-list"></i> Description</label>
+                        <textarea asp-for="Description" class="form-textarea" rows="3"
+                                  placeholder="Optional description of this folder..." maxlength="500"></textarea>
+                        <span asp-validation-for="Description" class="validation-message"></span>
+                        <div class="form-hint">Provide additional context about this folder (max 500 characters).</div>
+                    </div>
+
+                    @if (Model.AvailableParentFolders.Any())
+                    {
+                        <div class="form-group full-width">
+                            <label class="form-label"><i class="bi bi-diagram-3"></i> Parent Folder</label>
+                            <div class="parent-picker">
+                                <div class="form-check">
+                                    <input class="form-check-input" type="radio" name="parentFolderSelection"
+                                           id="noParent" value="none" @(Model.ParentFolderId == null ? "checked" : "") />
+                                    <label class="form-check-label" for="noParent">
+                                        <i class="bi bi-folder me-1"></i>Create at root level
+                                    </label>
+                                </div>
+                                @foreach (var folder in Model.AvailableParentFolders)
+                                {
+                                    <div class="form-check">
+                                        <input class="form-check-input" type="radio" name="parentFolderSelection"
+                                               id="parent_@folder.Id" value="@folder.Id" @(Model.ParentFolderId == folder.Id ? "checked" : "") />
+                                        <label class="form-check-label" for="parent_@folder.Id">
+                                            <i class="bi bi-folder me-1"></i>@folder.Name
+                                            @if (!string.IsNullOrEmpty(folder.Description))
+                                            {
+                                                <small class="text-muted d-block ms-4">@folder.Description</small>
+                                            }
+                                        </label>
                                     </div>
-                                    
-                                    @foreach (var folder in Model.AvailableParentFolders)
-                                    {
-                                        <div class="form-check">
-                                            <input class="form-check-input" type="radio" name="parentFolderSelection" 
-                                                   id="parent_@folder.Id" value="@folder.Id" 
-                                                   @(Model.ParentFolderId == folder.Id ? "checked" : "") />
-                                            <label class="form-check-label" for="parent_@folder.Id">
-                                                <i class="bi bi-folder me-1"></i>@folder.Name
-                                                @if (!string.IsNullOrEmpty(folder.Description))
-                                                {
-                                                    <small class="text-muted d-block ms-4">@folder.Description</small>
-                                                }
-                                            </label>
-                                        </div>
-                                    }
-                                </div>
-                                <div class="form-text">
-                                    Select where to create this folder in the hierarchy.
-                                </div>
+                                }
                             </div>
-                        }
-
-                        <div class="d-flex gap-2">
-                            <button type="submit" class="btn btn-primary">
-                                <i class="bi bi-check-circle me-1"></i>Create Folder
-                            </button>
-                            <a asp-page="/Folders/Index" asp-route-projectId="@Model.ProjectId" 
-                               class="btn btn-outline-secondary">
-                                Cancel
-                            </a>
+                            <div class="form-hint">Select where to create this folder in the hierarchy.</div>
                         </div>
-                    </form>
-                </div>
+                    }
+
+                    <div class="form-actions">
+                        <button type="submit" class="submit-btn"><i class="bi bi-check-circle"></i> Create Folder</button>
+                        <a asp-page="/Folders/Index" asp-route-projectId="@Model.ProjectId" class="cancel-btn">Cancel</a>
+                    </div>
+                </form>
             </div>
         </div>
 
         <div class="col-lg-4">
-            <!-- Preview Card -->
-            <div class="card">
-                <div class="card-header">
-                    <h5 class="mb-0">
-                        <i class="bi bi-eye me-2"></i>Preview
-                    </h5>
-                </div>
-                <div class="card-body">
-                    <div id="folderPreview">
-                        <div class="text-center text-muted py-4">
-                            <i class="bi bi-folder display-4"></i>
-                            <p class="mt-2">Enter folder details to see preview</p>
-                        </div>
+            <div class="content-card">
+                <h5 class="section-heading"><i class="bi bi-eye"></i> Preview</h5>
+                <div id="folderPreview">
+                    <div class="text-center text-muted py-4">
+                        <i class="bi bi-folder display-4"></i>
+                        <p class="mt-2">Enter folder details to see preview</p>
                     </div>
                 </div>
             </div>
 
-            <!-- Project Info Card -->
             @if (Model.Project != null)
             {
-                <div class="card mt-3">
-                    <div class="card-header">
-                        <h5 class="mb-0">
-                            <i class="bi bi-info-circle me-2"></i>Project Information
-                        </h5>
-                    </div>
-                    <div class="card-body">
-                        <div class="d-flex align-items-center mb-3">
-                            <div class="me-3">
-                                <i class="bi bi-@Model.Project.Icon" style="color: @Model.Project.Color; font-size: 1.5rem;"></i>
-                            </div>
-                            <div>
-                                <h6 class="mb-0">@Model.Project.Name</h6>
-                                <small class="text-muted">@Model.Project.Description</small>
-                            </div>
+                <div class="content-card mt-3">
+                    <h5 class="section-heading"><i class="bi bi-info-circle"></i> Project Information</h5>
+                    <div class="d-flex align-items-center mb-3">
+                        <i class="bi bi-@Model.Project.Icon me-3" style="color:@Model.Project.Color;font-size:1.5rem;"></i>
+                        <div>
+                            <h6 class="mb-0">@Model.Project.Name</h6>
+                            <small class="text-muted">@Model.Project.Description</small>
                         </div>
-                        <div class="row text-center">
-                            <div class="col-6">
-                                <div class="border-end">
-                                    <div class="h5 mb-0 text-primary">@Model.Project.DocumentCount</div>
-                                    <small class="text-muted">Documents</small>
-                                </div>
-                            </div>
-                            <div class="col-6">
-                                <div class="h5 mb-0 text-info">@Model.Project.FolderCount</div>
-                                <small class="text-muted">Folders</small>
-                            </div>
+                    </div>
+                    <div class="row text-center">
+                        <div class="col-6 border-end">
+                            <div class="h5 mb-0" style="color:var(--accent-color);">@Model.Project.DocumentCount</div>
+                            <small class="text-muted">Documents</small>
+                        </div>
+                        <div class="col-6">
+                            <div class="h5 mb-0" style="color:var(--info-color);">@Model.Project.FolderCount</div>
+                            <small class="text-muted">Folders</small>
                         </div>
                     </div>
                 </div>
@@ -201,9 +137,24 @@
     </div>
 </div>
 
+@section Styles {
+<style>
+    .section-heading { display: flex; align-items: center; gap: 0.5rem; color: var(--text-primary); font-weight: 600; margin-bottom: 1.25rem; }
+    .section-heading i { color: var(--accent-color); }
+    .parent-picker {
+        border: 1px solid var(--border-color); border-radius: 10px;
+        background: var(--surface-secondary); padding: 0.85rem 1rem; min-height: 120px;
+    }
+    .parent-picker .form-check { margin-bottom: 0.5rem; }
+    .parent-picker .form-check-label { cursor: pointer; padding-left: 0.25rem; color: var(--text-primary); }
+    .parent-picker .form-check-input:checked + .form-check-label { font-weight: 600; color: var(--accent-color); }
+    .folder-preview { padding: 1rem; border: 1px solid var(--border-color); border-radius: 10px; background: var(--surface-secondary); color: var(--text-primary); }
+</style>
+}
+
 @section Scripts {
     <script>
-        document.addEventListener('DOMContentLoaded', function() {
+        document.addEventListener('DOMContentLoaded', function () {
             const nameInput = document.getElementById('Name');
             const descriptionInput = document.getElementById('Description');
             const previewDiv = document.getElementById('folderPreview');
@@ -221,28 +172,16 @@
                             <div class="d-flex align-items-center mb-2">
                                 <i class="bi bi-folder-fill text-warning me-2" style="font-size: 1.2rem;"></i>
                                 <strong>${name}</strong>
-                            </div>
-                    `;
-
+                            </div>`;
                     if (description) {
                         previewHtml += `<p class="text-muted small mb-2">${description}</p>`;
                     }
-
                     if (selectedParent && selectedParent.value !== 'none') {
                         const parentLabel = selectedParent.nextElementSibling.textContent.trim();
-                        previewHtml += `
-                            <div class="alert alert-info small mb-0">
-                                <i class="bi bi-arrow-up me-1"></i>Will be created inside: <strong>${parentLabel}</strong>
-                            </div>
-                        `;
+                        previewHtml += `<div class="alert alert-info small mb-0"><i class="bi bi-arrow-up me-1"></i>Will be created inside: <strong>${parentLabel}</strong></div>`;
                     } else {
-                        previewHtml += `
-                            <div class="alert alert-success small mb-0">
-                                <i class="bi bi-check-circle me-1"></i>Will be created at root level
-                            </div>
-                        `;
+                        previewHtml += `<div class="alert alert-success small mb-0"><i class="bi bi-check-circle me-1"></i>Will be created at root level</div>`;
                     }
-
                     previewHtml += '</div>';
                     previewDiv.innerHTML = previewHtml;
                 } else {
@@ -250,35 +189,22 @@
                         <div class="text-center text-muted py-4">
                             <i class="bi bi-folder display-4"></i>
                             <p class="mt-2">Enter folder details to see preview</p>
-                        </div>
-                    `;
+                        </div>`;
                 }
             }
 
-            // Update preview on input changes
             nameInput.addEventListener('input', updatePreview);
             descriptionInput.addEventListener('input', updatePreview);
-
-            // Update parent folder selection
             parentFolderSelection.forEach(radio => {
-                radio.addEventListener('change', function() {
-                    if (this.value === 'none') {
-                        parentFolderIdInput.value = '';
-                    } else {
-                        parentFolderIdInput.value = this.value;
-                    }
+                radio.addEventListener('change', function () {
+                    parentFolderIdInput.value = this.value === 'none' ? '' : this.value;
                     updatePreview();
                 });
             });
-
-            // Initial preview update
             updatePreview();
 
-            // Form validation
-            const form = document.getElementById('createFolderForm');
-            form.addEventListener('submit', function(e) {
-                const name = nameInput.value.trim();
-                if (!name) {
+            document.getElementById('createFolderForm').addEventListener('submit', function (e) {
+                if (!nameInput.value.trim()) {
                     e.preventDefault();
                     nameInput.focus();
                     return false;
@@ -287,90 +213,3 @@
         });
     </script>
 }
-
-<style>
-    .folder-preview {
-        padding: 1rem;
-        border: 1px solid #e9ecef;
-        border-radius: 0.375rem;
-        background-color: #f8f9fa;
-    }
-
-    .form-check {
-        margin-bottom: 0.5rem;
-    }
-
-    .form-check-label {
-        cursor: pointer;
-        padding-left: 0.25rem;
-    }
-
-    .form-check-input:checked + .form-check-label {
-        font-weight: 500;
-    }
-
-    .alert {
-        border: none;
-        border-radius: 0.375rem;
-        margin-bottom: 0;
-    }
-
-    .alert-info {
-        background-color: #d1ecf1;
-        color: #0c5460;
-    }
-
-    .alert-success {
-        background-color: #d4edda;
-        color: #155724;
-    }
-
-    .breadcrumb {
-        background-color: transparent;
-        padding: 0;
-        margin: 0;
-    }
-
-    .breadcrumb-item + .breadcrumb-item::before {
-        content: ">";
-        color: #6c757d;
-    }
-
-    .card {
-        border: 1px solid #e9ecef;
-        border-radius: 0.5rem;
-        box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.075);
-    }
-
-    .card-header {
-        background-color: #f8f9fa;
-        border-bottom: 1px solid #e9ecef;
-        padding: 1rem 1.25rem;
-    }
-
-    .form-control:focus {
-        border-color: #86b7fe;
-        box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.25);
-    }
-
-    .btn {
-        border-radius: 0.375rem;
-        font-weight: 500;
-    }
-
-    .btn-primary {
-        background-color: #0d6efd;
-        border-color: #0d6efd;
-    }
-
-    .btn-primary:hover {
-        background-color: #0b5ed7;
-        border-color: #0a58ca;
-    }
-
-    @@media (max-width: 991.98px) {
-        .col-lg-4 {
-            margin-top: 1.5rem;
-        }
-    }
-</style>

--- a/src/DocFlowHub.Web/Pages/Folders/Edit.cshtml
+++ b/src/DocFlowHub.Web/Pages/Folders/Edit.cshtml
@@ -4,251 +4,153 @@
     ViewData["Title"] = $"Edit Folder: {Model.Folder?.Name}";
 }
 
-<div class="container-fluid">
-    <!-- Breadcrumb Navigation -->
-    <nav aria-label="breadcrumb" class="mb-4">
-        <ol class="breadcrumb">
-            <li class="breadcrumb-item">
-                <a asp-page="/Index" class="text-decoration-none">
-                    <i class="bi bi-house-door me-1"></i>Home
-                </a>
-            </li>
-            <li class="breadcrumb-item">
-                <a asp-page="/Projects/Index" class="text-decoration-none">
-                    <i class="bi bi-kanban me-1"></i>Projects
-                </a>
-            </li>
+<div class="page-container page-transition">
+    <!-- Breadcrumb -->
+    <nav aria-label="breadcrumb">
+        <ol class="breadcrumb-modern">
+            <li><a asp-page="/Index">Home</a></li>
+            <li class="breadcrumb-sep">/</li>
+            <li><a asp-page="/Projects/Index">Projects</a></li>
             @if (Model.Project != null)
             {
-                <li class="breadcrumb-item">
-                    <a asp-page="/Projects/Details" asp-route-id="@Model.Project.Id" class="text-decoration-none">
-                        <i class="bi bi-@Model.Project.Icon me-1"></i>@Model.Project.Name
-                    </a>
-                </li>
-                <li class="breadcrumb-item">
-                    <a asp-page="/Folders/Index" asp-route-projectId="@Model.Project.Id" class="text-decoration-none">
-                        <i class="bi bi-folder me-1"></i>Folders
-                    </a>
-                </li>
+                <li class="breadcrumb-sep">/</li>
+                <li><a asp-page="/Projects/Details" asp-route-id="@Model.Project.Id">@Model.Project.Name</a></li>
+                <li class="breadcrumb-sep">/</li>
+                <li><a asp-page="/Folders/Index" asp-route-projectId="@Model.Project.Id">Folders</a></li>
             }
             @if (Model.Folder != null)
             {
-                <li class="breadcrumb-item">
-                    <a asp-page="/Folders/Details" asp-route-id="@Model.Folder.Id" class="text-decoration-none">
-                        <i class="bi bi-folder me-1"></i>@Model.Folder.Name
-                    </a>
-                </li>
+                <li class="breadcrumb-sep">/</li>
+                <li><a asp-page="/Folders/Details" asp-route-id="@Model.Folder.Id">@Model.Folder.Name</a></li>
             }
-            <li class="breadcrumb-item active" aria-current="page">
-                <i class="bi bi-pencil me-1"></i>Edit
-            </li>
+            <li class="breadcrumb-sep">/</li>
+            <li class="active" aria-current="page">Edit</li>
         </ol>
     </nav>
 
     @if (Model.Folder == null)
     {
-        <!-- Error State -->
-        <div class="text-center py-5">
-            <div class="mb-3">
-                <i class="bi bi-exclamation-triangle display-1 text-warning"></i>
-            </div>
-            <h4 class="text-muted mb-2">Folder not found</h4>
-            <p class="text-muted mb-4">
-                The folder you're trying to edit doesn't exist or you don't have access to it.
-            </p>
-            <a asp-page="/Projects/Index" class="btn btn-primary">
-                <i class="bi bi-arrow-left me-1"></i>Back to Projects
-            </a>
+        <div class="content-card text-center py-5">
+            <i class="bi bi-exclamation-triangle display-1 text-warning"></i>
+            <h4 class="text-muted mt-3 mb-2">Folder not found</h4>
+            <p class="text-muted mb-4">The folder you're trying to edit doesn't exist or you don't have access to it.</p>
+            <a asp-page="/Projects/Index" class="submit-btn d-inline-flex"><i class="bi bi-arrow-left"></i> Back to Projects</a>
         </div>
     }
     else
     {
         <!-- Page Header -->
-        <div class="d-flex justify-content-between align-items-center mb-4">
+        <div class="page-header d-flex justify-content-between align-items-center flex-wrap gap-2">
             <div>
-                <h1 class="h3 mb-1">
-                    <i class="bi bi-pencil-square me-2"></i>Edit Folder
-                </h1>
-                <p class="text-muted mb-0">
-                    Updating folder <strong>@Model.Folder.Name</strong>
-                </p>
+                <h1 class="page-title"><div class="page-icon">✏️</div> Edit Folder</h1>
+                <p class="page-subtitle">Updating folder <strong>@Model.Folder.Name</strong></p>
             </div>
-            <div>
-                <a asp-page="/Folders/Details" asp-route-id="@Model.Folder.Id" 
-                   class="btn btn-outline-secondary">
-                    <i class="bi bi-arrow-left me-1"></i>Back to Folder
-                </a>
-            </div>
+            <a asp-page="/Folders/Details" asp-route-id="@Model.Folder.Id" class="cancel-btn">
+                <i class="bi bi-arrow-left"></i> Back to Folder
+            </a>
         </div>
 
-        <div class="row">
+        <div class="row g-4">
             <div class="col-lg-8">
-                <!-- Edit Folder Form -->
-                <div class="card">
-                    <div class="card-header">
-                        <h5 class="mb-0">
-                            <i class="bi bi-folder me-2"></i>Folder Details
-                        </h5>
-                    </div>
-                    <div class="card-body">
-                        <form method="post" id="editFolderForm">
-                            <input type="hidden" asp-for="Id" />
-                            
-                            <div class="mb-3">
-                                <label asp-for="Name" class="form-label">Folder Name <span class="text-danger">*</span></label>
-                                <input asp-for="Name" class="form-control" placeholder="Enter folder name..." 
-                                       maxlength="100" required />
-                                <div class="form-text">
-                                    Choose a descriptive name for your folder (max 100 characters).
-                                </div>
-                                <span asp-validation-for="Name" class="text-danger"></span>
-                            </div>
+                <div class="form-card">
+                    <h5 class="section-heading"><i class="bi bi-folder"></i> Folder Details</h5>
+                    <form method="post" id="editFolderForm">
+                        <input type="hidden" asp-for="Id" />
 
-                            <div class="mb-3">
-                                <label asp-for="Description" class="form-label">Description</label>
-                                <textarea asp-for="Description" class="form-control" rows="3" 
-                                          placeholder="Optional description of this folder..." 
-                                          maxlength="500"></textarea>
-                                <div class="form-text">
-                                    Provide additional context about this folder (max 500 characters).
-                                </div>
-                                <span asp-validation-for="Description" class="text-danger"></span>
-                            </div>
+                        <div class="form-group full-width">
+                            <label asp-for="Name" class="form-label"><i class="bi bi-card-text"></i> Folder Name *</label>
+                            <input asp-for="Name" class="form-input" placeholder="Enter folder name..." maxlength="100" required />
+                            <span asp-validation-for="Name" class="validation-message"></span>
+                            <div class="form-hint">Choose a descriptive name for your folder (max 100 characters).</div>
+                        </div>
 
-                            @if (Model.AvailableParentFolders.Any())
-                            {
-                                <div class="mb-3">
-                                    <label class="form-label">Parent Folder</label>
-                                    <div class="form-control" style="height: auto; min-height: 120px;">
-                                        <div class="mb-2">
-                                            <div class="form-check">
-                                                <input class="form-check-input" type="radio" name="parentFolderSelection" 
-                                                       id="noParent" value="none" 
-                                                       @(Model.ParentFolderId == null ? "checked" : "") />
-                                                <label class="form-check-label" for="noParent">
-                                                    <i class="bi bi-folder me-1"></i>Move to root level
-                                                </label>
-                                            </div>
+                        <div class="form-group full-width">
+                            <label asp-for="Description" class="form-label"><i class="bi bi-card-list"></i> Description</label>
+                            <textarea asp-for="Description" class="form-textarea" rows="3"
+                                      placeholder="Optional description of this folder..." maxlength="500"></textarea>
+                            <span asp-validation-for="Description" class="validation-message"></span>
+                            <div class="form-hint">Provide additional context about this folder (max 500 characters).</div>
+                        </div>
+
+                        @if (Model.AvailableParentFolders.Any())
+                        {
+                            <div class="form-group full-width">
+                                <label class="form-label"><i class="bi bi-diagram-3"></i> Parent Folder</label>
+                                <div class="parent-picker">
+                                    <div class="form-check">
+                                        <input class="form-check-input" type="radio" name="parentFolderSelection"
+                                               id="noParent" value="none" @(Model.ParentFolderId == null ? "checked" : "") />
+                                        <label class="form-check-label" for="noParent"><i class="bi bi-folder me-1"></i>Move to root level</label>
+                                    </div>
+                                    @foreach (var folder in Model.AvailableParentFolders)
+                                    {
+                                        <div class="form-check">
+                                            <input class="form-check-input" type="radio" name="parentFolderSelection"
+                                                   id="parent_@folder.Id" value="@folder.Id" @(Model.ParentFolderId == folder.Id ? "checked" : "") />
+                                            <label class="form-check-label" for="parent_@folder.Id">
+                                                <i class="bi bi-folder me-1"></i>@folder.Name
+                                                @if (!string.IsNullOrEmpty(folder.Description))
+                                                {
+                                                    <small class="text-muted d-block ms-4">@folder.Description</small>
+                                                }
+                                            </label>
                                         </div>
-                                        
-                                        @foreach (var folder in Model.AvailableParentFolders)
-                                        {
-                                            <div class="form-check">
-                                                <input class="form-check-input" type="radio" name="parentFolderSelection" 
-                                                       id="parent_@folder.Id" value="@folder.Id" 
-                                                       @(Model.ParentFolderId == folder.Id ? "checked" : "") />
-                                                <label class="form-check-label" for="parent_@folder.Id">
-                                                    <i class="bi bi-folder me-1"></i>@folder.Name
-                                                    @if (!string.IsNullOrEmpty(folder.Description))
-                                                    {
-                                                        <small class="text-muted d-block ms-4">@folder.Description</small>
-                                                    }
-                                                </label>
-                                            </div>
-                                        }
-                                    </div>
-                                    <div class="form-text">
-                                        Select where to move this folder in the hierarchy.
-                                    </div>
+                                    }
                                 </div>
-                            }
-
-                            <div class="d-flex gap-2">
-                                <button type="submit" class="btn btn-primary">
-                                    <i class="bi bi-check-circle me-1"></i>Save Changes
-                                </button>
-                                <a asp-page="/Folders/Details" asp-route-id="@Model.Folder.Id" 
-                                   class="btn btn-outline-secondary">
-                                    Cancel
-                                </a>
+                                <div class="form-hint">Select where to move this folder in the hierarchy.</div>
                             </div>
-                        </form>
-                    </div>
+                        }
+
+                        <div class="form-actions">
+                            <button type="submit" class="submit-btn"><i class="bi bi-check-circle"></i> Save Changes</button>
+                            <a asp-page="/Folders/Details" asp-route-id="@Model.Folder.Id" class="cancel-btn">Cancel</a>
+                        </div>
+                    </form>
                 </div>
             </div>
 
             <div class="col-lg-4">
-                <!-- Preview Card -->
-                <div class="card">
-                    <div class="card-header">
-                        <h5 class="mb-0">
-                            <i class="bi bi-eye me-2"></i>Preview
-                        </h5>
-                    </div>
-                    <div class="card-body">
-                        <div id="folderPreview">
-                            <div class="text-center text-muted py-4">
-                                <i class="bi bi-folder display-4"></i>
-                                <p class="mt-2">Enter folder details to see preview</p>
-                            </div>
+                <div class="content-card">
+                    <h5 class="section-heading"><i class="bi bi-eye"></i> Preview</h5>
+                    <div id="folderPreview">
+                        <div class="text-center text-muted py-4">
+                            <i class="bi bi-folder display-4"></i>
+                            <p class="mt-2">Enter folder details to see preview</p>
                         </div>
                     </div>
                 </div>
 
-                <!-- Current Folder Info -->
-                <div class="card mt-3">
-                    <div class="card-header">
-                        <h5 class="mb-0">
-                            <i class="bi bi-info-circle me-2"></i>Current Information
-                        </h5>
-                    </div>
-                    <div class="card-body">
-                        <dl class="row mb-0">
-                            <dt class="col-sm-4">Name</dt>
-                            <dd class="col-sm-8">@Model.Folder.Name</dd>
-                            
-                            <dt class="col-sm-4">Description</dt>
-                            <dd class="col-sm-8">
-                                @(string.IsNullOrEmpty(Model.Folder.Description) ? "No description" : Model.Folder.Description)
-                            </dd>
-                            
-                            <dt class="col-sm-4">Created</dt>
-                            <dd class="col-sm-8">@Model.Folder.CreatedAt.ToString("MMM dd, yyyy")</dd>
-                            
-                            <dt class="col-sm-4">Modified</dt>
-                            <dd class="col-sm-8">
-                                @(Model.Folder.UpdatedAt?.ToString("MMM dd, yyyy") ?? "Never")
-                            </dd>
-                            
-                            <dt class="col-sm-4">Level</dt>
-                            <dd class="col-sm-8">@Model.Folder.Level</dd>
-                            
-                            <dt class="col-sm-4">Documents</dt>
-                            <dd class="col-sm-8">@Model.Folder.DocumentCount</dd>
-                        </dl>
-                    </div>
+                <div class="content-card mt-3">
+                    <h5 class="section-heading"><i class="bi bi-info-circle"></i> Current Information</h5>
+                    <dl class="info-dl mb-0">
+                        <dt>Name</dt><dd>@Model.Folder.Name</dd>
+                        <dt>Description</dt><dd>@(string.IsNullOrEmpty(Model.Folder.Description) ? "No description" : Model.Folder.Description)</dd>
+                        <dt>Created</dt><dd>@Model.Folder.CreatedAt.ToString("MMM dd, yyyy")</dd>
+                        <dt>Modified</dt><dd>@(Model.Folder.UpdatedAt?.ToString("MMM dd, yyyy") ?? "Never")</dd>
+                        <dt>Level</dt><dd>@Model.Folder.Level</dd>
+                        <dt>Documents</dt><dd>@Model.Folder.DocumentCount</dd>
+                    </dl>
                 </div>
 
-                <!-- Project Info Card -->
                 @if (Model.Project != null)
                 {
-                    <div class="card mt-3">
-                        <div class="card-header">
-                            <h5 class="mb-0">
-                                <i class="bi bi-info-circle me-2"></i>Project Information
-                            </h5>
-                        </div>
-                        <div class="card-body">
-                            <div class="d-flex align-items-center mb-3">
-                                <div class="me-3">
-                                    <i class="bi bi-@Model.Project.Icon" style="color: @Model.Project.Color; font-size: 1.5rem;"></i>
-                                </div>
-                                <div>
-                                    <h6 class="mb-0">@Model.Project.Name</h6>
-                                    <small class="text-muted">@Model.Project.Description</small>
-                                </div>
+                    <div class="content-card mt-3">
+                        <h5 class="section-heading"><i class="bi bi-kanban"></i> Project Information</h5>
+                        <div class="d-flex align-items-center mb-3">
+                            <i class="bi bi-@Model.Project.Icon me-3" style="color:@Model.Project.Color;font-size:1.5rem;"></i>
+                            <div>
+                                <h6 class="mb-0">@Model.Project.Name</h6>
+                                <small class="text-muted">@Model.Project.Description</small>
                             </div>
-                            <div class="row text-center">
-                                <div class="col-6">
-                                    <div class="border-end">
-                                        <div class="h5 mb-0 text-primary">@Model.Project.DocumentCount</div>
-                                        <small class="text-muted">Documents</small>
-                                    </div>
-                                </div>
-                                <div class="col-6">
-                                    <div class="h5 mb-0 text-info">@Model.Project.FolderCount</div>
-                                    <small class="text-muted">Folders</small>
-                                </div>
+                        </div>
+                        <div class="row text-center">
+                            <div class="col-6 border-end">
+                                <div class="h5 mb-0" style="color:var(--accent-color);">@Model.Project.DocumentCount</div>
+                                <small class="text-muted">Documents</small>
+                            </div>
+                            <div class="col-6">
+                                <div class="h5 mb-0" style="color:var(--info-color);">@Model.Project.FolderCount</div>
+                                <small class="text-muted">Folders</small>
                             </div>
                         </div>
                     </div>
@@ -258,14 +160,34 @@
     }
 </div>
 
+@section Styles {
+<style>
+    .section-heading { display: flex; align-items: center; gap: 0.5rem; color: var(--text-primary); font-weight: 600; margin-bottom: 1.25rem; }
+    .section-heading i { color: var(--accent-color); }
+    .parent-picker {
+        border: 1px solid var(--border-color); border-radius: 10px;
+        background: var(--surface-secondary); padding: 0.85rem 1rem; min-height: 120px;
+    }
+    .parent-picker .form-check { margin-bottom: 0.5rem; }
+    .parent-picker .form-check-label { cursor: pointer; padding-left: 0.25rem; color: var(--text-primary); }
+    .parent-picker .form-check-input:checked + .form-check-label { font-weight: 600; color: var(--accent-color); }
+    .folder-preview { padding: 1rem; border: 1px solid var(--border-color); border-radius: 10px; background: var(--surface-secondary); color: var(--text-primary); }
+    .info-dl { display: grid; grid-template-columns: 40% 60%; row-gap: 0.5rem; font-size: 0.9rem; }
+    .info-dl dt { font-weight: 600; color: var(--text-primary); }
+    .info-dl dd { margin: 0; color: var(--text-secondary); }
+</style>
+}
+
 @section Scripts {
     <script>
-        document.addEventListener('DOMContentLoaded', function() {
+        document.addEventListener('DOMContentLoaded', function () {
             const nameInput = document.getElementById('Name');
             const descriptionInput = document.getElementById('Description');
             const previewDiv = document.getElementById('folderPreview');
             const parentFolderSelection = document.querySelectorAll('input[name="parentFolderSelection"]');
             const parentFolderIdInput = document.getElementById('ParentFolderId');
+
+            if (!nameInput) return; // not-found state
 
             function updatePreview() {
                 const name = nameInput.value.trim();
@@ -278,28 +200,16 @@
                             <div class="d-flex align-items-center mb-2">
                                 <i class="bi bi-folder-fill text-warning me-2" style="font-size: 1.2rem;"></i>
                                 <strong>${name}</strong>
-                            </div>
-                    `;
-
+                            </div>`;
                     if (description) {
                         previewHtml += `<p class="text-muted small mb-2">${description}</p>`;
                     }
-
                     if (selectedParent && selectedParent.value !== 'none') {
                         const parentLabel = selectedParent.nextElementSibling.textContent.trim();
-                        previewHtml += `
-                            <div class="alert alert-info small mb-0">
-                                <i class="bi bi-arrow-up me-1"></i>Will be moved to: <strong>${parentLabel}</strong>
-                            </div>
-                        `;
+                        previewHtml += `<div class="alert alert-info small mb-0"><i class="bi bi-arrow-up me-1"></i>Will be moved to: <strong>${parentLabel}</strong></div>`;
                     } else {
-                        previewHtml += `
-                            <div class="alert alert-success small mb-0">
-                                <i class="bi bi-check-circle me-1"></i>Will be at root level
-                            </div>
-                        `;
+                        previewHtml += `<div class="alert alert-success small mb-0"><i class="bi bi-check-circle me-1"></i>Will be at root level</div>`;
                     }
-
                     previewHtml += '</div>';
                     previewDiv.innerHTML = previewHtml;
                 } else {
@@ -307,35 +217,22 @@
                         <div class="text-center text-muted py-4">
                             <i class="bi bi-folder display-4"></i>
                             <p class="mt-2">Enter folder details to see preview</p>
-                        </div>
-                    `;
+                        </div>`;
                 }
             }
 
-            // Update preview on input changes
             nameInput.addEventListener('input', updatePreview);
             descriptionInput.addEventListener('input', updatePreview);
-
-            // Update parent folder selection
             parentFolderSelection.forEach(radio => {
-                radio.addEventListener('change', function() {
-                    if (this.value === 'none') {
-                        parentFolderIdInput.value = '';
-                    } else {
-                        parentFolderIdInput.value = this.value;
-                    }
+                radio.addEventListener('change', function () {
+                    if (parentFolderIdInput) parentFolderIdInput.value = this.value === 'none' ? '' : this.value;
                     updatePreview();
                 });
             });
-
-            // Initial preview update
             updatePreview();
 
-            // Form validation
-            const form = document.getElementById('editFolderForm');
-            form.addEventListener('submit', function(e) {
-                const name = nameInput.value.trim();
-                if (!name) {
+            document.getElementById('editFolderForm').addEventListener('submit', function (e) {
+                if (!nameInput.value.trim()) {
                     e.preventDefault();
                     nameInput.focus();
                     return false;
@@ -344,99 +241,3 @@
         });
     </script>
 }
-
-<style>
-    .folder-preview {
-        padding: 1rem;
-        border: 1px solid #e9ecef;
-        border-radius: 0.375rem;
-        background-color: #f8f9fa;
-    }
-
-    .form-check {
-        margin-bottom: 0.5rem;
-    }
-
-    .form-check-label {
-        cursor: pointer;
-        padding-left: 0.25rem;
-    }
-
-    .form-check-input:checked + .form-check-label {
-        font-weight: 500;
-    }
-
-    .alert {
-        border: none;
-        border-radius: 0.375rem;
-        margin-bottom: 0;
-    }
-
-    .alert-info {
-        background-color: #d1ecf1;
-        color: #0c5460;
-    }
-
-    .alert-success {
-        background-color: #d4edda;
-        color: #155724;
-    }
-
-    .breadcrumb {
-        background-color: transparent;
-        padding: 0;
-        margin: 0;
-    }
-
-    .breadcrumb-item + .breadcrumb-item::before {
-        content: ">";
-        color: #6c757d;
-    }
-
-    .card {
-        border: 1px solid #e9ecef;
-        border-radius: 0.5rem;
-        box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.075);
-    }
-
-    .card-header {
-        background-color: #f8f9fa;
-        border-bottom: 1px solid #e9ecef;
-        padding: 1rem 1.25rem;
-    }
-
-    .form-control:focus {
-        border-color: #86b7fe;
-        box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.25);
-    }
-
-    .btn {
-        border-radius: 0.375rem;
-        font-weight: 500;
-    }
-
-    .btn-primary {
-        background-color: #0d6efd;
-        border-color: #0d6efd;
-    }
-
-    .btn-primary:hover {
-        background-color: #0b5ed7;
-        border-color: #0a58ca;
-    }
-
-    dl.row dt {
-        font-weight: 600;
-        color: #495057;
-    }
-
-    dl.row dd {
-        color: #6c757d;
-    }
-
-    @@media (max-width: 991.98px) {
-        .col-lg-4 {
-            margin-top: 1.5rem;
-        }
-    }
-</style>

--- a/src/DocFlowHub.Web/Pages/Folders/Edit.cshtml
+++ b/src/DocFlowHub.Web/Pages/Folders/Edit.cshtml
@@ -162,15 +162,7 @@
 
 @section Styles {
 <style>
-    .section-heading { display: flex; align-items: center; gap: 0.5rem; color: var(--text-primary); font-weight: 600; margin-bottom: 1.25rem; }
-    .section-heading i { color: var(--accent-color); }
-    .parent-picker {
-        border: 1px solid var(--border-color); border-radius: 10px;
-        background: var(--surface-secondary); padding: 0.85rem 1rem; min-height: 120px;
-    }
-    .parent-picker .form-check { margin-bottom: 0.5rem; }
-    .parent-picker .form-check-label { cursor: pointer; padding-left: 0.25rem; color: var(--text-primary); }
-    .parent-picker .form-check-input:checked + .form-check-label { font-weight: 600; color: var(--accent-color); }
+    /* .section-heading and .parent-picker live in components.css */
     .folder-preview { padding: 1rem; border: 1px solid var(--border-color); border-radius: 10px; background: var(--surface-secondary); color: var(--text-primary); }
     .info-dl { display: grid; grid-template-columns: 40% 60%; row-gap: 0.5rem; font-size: 0.9rem; }
     .info-dl dt { font-weight: 600; color: var(--text-primary); }

--- a/src/DocFlowHub.Web/Pages/Projects/Create.cshtml
+++ b/src/DocFlowHub.Web/Pages/Projects/Create.cshtml
@@ -4,247 +4,207 @@
     ViewData["Title"] = "Create Project";
 }
 
-<div class="container page-transition">
+<div class="page-container page-transition">
     <!-- Breadcrumb -->
-    <nav aria-label="breadcrumb" class="mb-4">
-        <ol class="breadcrumb">
-            <li class="breadcrumb-item"><a asp-page="/Index">Home</a></li>
-            <li class="breadcrumb-item"><a asp-page="./Index">Projects</a></li>
-            <li class="breadcrumb-item active" aria-current="page">Create</li>
+    <nav aria-label="breadcrumb">
+        <ol class="breadcrumb-modern">
+            <li><a asp-page="/Index">Home</a></li>
+            <li class="breadcrumb-sep">/</li>
+            <li><a asp-page="./Index">Projects</a></li>
+            <li class="breadcrumb-sep">/</li>
+            <li class="active" aria-current="page">Create</li>
         </ol>
     </nav>
 
+    <!-- Page Header -->
+    <div class="page-header">
+        <h1 class="page-title">
+            <div class="page-icon">📁</div>
+            Create New Project
+        </h1>
+        <p class="page-subtitle">Organize your documents into a new project workspace</p>
+    </div>
+
+    @if (!string.IsNullOrEmpty(Model.ErrorMessage))
+    {
+        <div class="validation-summary" style="display:block;">
+            <i class="bi bi-exclamation-triangle-fill me-2"></i>@Model.ErrorMessage
+        </div>
+    }
+
     <div class="row justify-content-center">
-        <div class="col-lg-8">
-            <div class="card shadow-sm">
-                <div class="card-header bg-primary text-white">
-                    <h1 class="card-title mb-0 h4">
-                        <i class="bi bi-plus-circle me-2"></i>
-                        Create New Project
-                    </h1>
-                </div>
-                <div class="card-body">
-                    @if (!string.IsNullOrEmpty(Model.ErrorMessage))
-                    {
-                        <div class="alert alert-danger alert-dismissible fade show" role="alert">
-                            <i class="bi bi-exclamation-triangle-fill me-2"></i>
-                            @Model.ErrorMessage
-                            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-                        </div>
-                    }
+        <div class="col-lg-9">
+            <div class="form-card">
+                <form method="post" id="create-project-form">
+                    <div asp-validation-summary="ModelOnly" class="validation-summary"></div>
 
-                    <form method="post" id="create-project-form">
-                        <!-- Project Basic Information -->
-                        <div class="row">
-                            <div class="col-md-8">
-                                <div class="mb-3">
-                                    <label asp-for="Name" class="form-label fw-bold">
-                                        <i class="bi bi-card-text me-1"></i> Project Name *
-                                    </label>
-                                    <input asp-for="Name" class="form-control" placeholder="Enter project name..." autofocus />
-                                    <span asp-validation-for="Name" class="text-danger"></span>
-                                </div>
-                            </div>
-                            
-                            <div class="col-md-4">
-                                <div class="mb-3">
-                                    <label asp-for="Color" class="form-label fw-bold">
-                                        <i class="bi bi-palette me-1"></i> Project Color
-                                    </label>
-                                    <div class="d-flex align-items-center">
-                                        <input asp-for="Color" type="color" class="form-control form-control-color me-2" style="width: 50px; height: 38px;" />
-                                        <input type="text" id="ColorText" name="ColorText" class="form-control flex-grow-1" placeholder="#0d6efd" />
-                                    </div>
-                                    <span asp-validation-for="Color" class="text-danger"></span>
-                                </div>
-                            </div>
-                        </div>
-
-                        <div class="mb-3">
-                            <label asp-for="Description" class="form-label fw-bold">
-                                <i class="bi bi-card-list me-1"></i> Description
+                    <div class="form-row">
+                        <div class="form-group full-width" style="grid-column: span 1;">
+                            <label asp-for="Name" class="form-label">
+                                <i class="bi bi-card-text"></i> Project Name *
                             </label>
-                            <textarea asp-for="Description" class="form-control" rows="3" 
-                                      placeholder="Enter a brief description of your project..."></textarea>
-                            <span asp-validation-for="Description" class="text-danger"></span>
+                            <input asp-for="Name" class="form-input" placeholder="Enter project name..." autofocus />
+                            <span asp-validation-for="Name" class="validation-message"></span>
                         </div>
 
-                        <!-- Icon Selection -->
-                        <div class="mb-4">
-                            <label asp-for="Icon" class="form-label fw-bold">
-                                <i class="bi bi-emoji-smile me-1"></i> Project Icon
+                        <div class="form-group">
+                            <label asp-for="Color" class="form-label">
+                                <i class="bi bi-palette"></i> Project Color
                             </label>
-                            <div class="icon-selection">
-                                <div class="row g-2">
-                                    <div class="col-auto">
-                                        <input type="radio" class="btn-check" name="Icon" value="kanban" id="icon-kanban" checked />
-                                        <label class="btn btn-outline-secondary icon-option" for="icon-kanban">
-                                            <i class="bi bi-kanban"></i>
-                                        </label>
-                                    </div>
-                                    <div class="col-auto">
-                                        <input type="radio" class="btn-check" name="Icon" value="folder" id="icon-folder" />
-                                        <label class="btn btn-outline-secondary icon-option" for="icon-folder">
-                                            <i class="bi bi-folder"></i>
-                                        </label>
-                                    </div>
-                                    <div class="col-auto">
-                                        <input type="radio" class="btn-check" name="Icon" value="briefcase" id="icon-briefcase" />
-                                        <label class="btn btn-outline-secondary icon-option" for="icon-briefcase">
-                                            <i class="bi bi-briefcase"></i>
-                                        </label>
-                                    </div>
-                                    <div class="col-auto">
-                                        <input type="radio" class="btn-check" name="Icon" value="building" id="icon-building" />
-                                        <label class="btn btn-outline-secondary icon-option" for="icon-building">
-                                            <i class="bi bi-building"></i>
-                                        </label>
-                                    </div>
-                                    <div class="col-auto">
-                                        <input type="radio" class="btn-check" name="Icon" value="diagram-3" id="icon-diagram" />
-                                        <label class="btn btn-outline-secondary icon-option" for="icon-diagram">
-                                            <i class="bi bi-diagram-3"></i>
-                                        </label>
-                                    </div>
-                                    <div class="col-auto">
-                                        <input type="radio" class="btn-check" name="Icon" value="gear" id="icon-gear" />
-                                        <label class="btn btn-outline-secondary icon-option" for="icon-gear">
-                                            <i class="bi bi-gear"></i>
-                                        </label>
-                                    </div>
-                                    <div class="col-auto">
-                                        <input type="radio" class="btn-check" name="Icon" value="lightbulb" id="icon-lightbulb" />
-                                        <label class="btn btn-outline-secondary icon-option" for="icon-lightbulb">
-                                            <i class="bi bi-lightbulb"></i>
-                                        </label>
-                                    </div>
-                                    <div class="col-auto">
-                                        <input type="radio" class="btn-check" name="Icon" value="star" id="icon-star" />
-                                        <label class="btn btn-outline-secondary icon-option" for="icon-star">
-                                            <i class="bi bi-star"></i>
-                                        </label>
-                                    </div>
-                                </div>
-                                <span asp-validation-for="Icon" class="text-danger"></span>
+                            <div class="d-flex align-items-center gap-2">
+                                <input asp-for="Color" type="color" class="color-swatch" />
+                                <input type="text" id="ColorText" name="ColorText" class="form-input flex-grow-1" placeholder="#0d6efd" />
+                            </div>
+                            <span asp-validation-for="Color" class="validation-message"></span>
+                        </div>
+                    </div>
+
+                    <div class="form-group full-width">
+                        <label asp-for="Description" class="form-label">
+                            <i class="bi bi-card-list"></i> Description
+                        </label>
+                        <textarea asp-for="Description" class="form-textarea" rows="3"
+                                  placeholder="Enter a brief description of your project..."></textarea>
+                        <span asp-validation-for="Description" class="validation-message"></span>
+                    </div>
+
+                    <!-- Icon Selection -->
+                    <div class="form-group full-width">
+                        <label asp-for="Icon" class="form-label">
+                            <i class="bi bi-emoji-smile"></i> Project Icon
+                        </label>
+                        <div class="icon-selection">
+                            @foreach (var (value, isChecked) in new[] {
+                                ("kanban", true), ("folder", false), ("briefcase", false), ("building", false),
+                                ("diagram-3", false), ("gear", false), ("lightbulb", false), ("star", false) })
+                            {
+                                <input type="radio" class="btn-check" name="Icon" value="@value" id="icon-@value" checked="@isChecked" />
+                                <label class="icon-option" for="icon-@value">
+                                    <i class="bi bi-@value"></i>
+                                </label>
+                            }
+                        </div>
+                        <span asp-validation-for="Icon" class="validation-message"></span>
+                    </div>
+
+                    <!-- Project Preview -->
+                    <div class="form-group full-width">
+                        <label class="form-label"><i class="bi bi-eye"></i> Preview</label>
+                        <div class="project-preview">
+                            <div class="project-icon">
+                                <i id="preview-icon" class="bi bi-kanban" style="color:#0d6efd;font-size:2rem;"></i>
+                            </div>
+                            <div>
+                                <h5 class="mb-1" id="preview-name">Project Name</h5>
+                                <p class="text-muted mb-0" id="preview-description">Project description will appear here...</p>
                             </div>
                         </div>
+                    </div>
 
-                        <!-- Project Preview -->
-                        <div class="mb-4">
-                            <label class="form-label fw-bold">
-                                <i class="bi bi-eye me-1"></i> Preview
-                            </label>
-                            <div class="project-preview card">
-                                <div class="card-body">
-                                    <div class="d-flex align-items-center">
-                                        <div class="project-icon me-3">
-                                            <i id="preview-icon" class="bi bi-kanban" style="color: #0d6efd; font-size: 2rem;"></i>
-                                        </div>
-                                        <div>
-                                            <h5 class="card-title mb-1" id="preview-name">Project Name</h5>
-                                            <p class="card-text text-muted mb-0" id="preview-description">Project description will appear here...</p>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-
-                        <!-- Action Buttons -->
-                        <div class="d-flex justify-content-between">
-                            <a asp-page="./Index" class="btn btn-secondary">
-                                <i class="bi bi-arrow-left me-1"></i> Cancel
-                            </a>
-                            <button type="submit" class="btn btn-primary">
-                                <i class="bi bi-plus-circle me-1"></i> Create Project
-                            </button>
-                        </div>
-                    </form>
-                </div>
+                    <!-- Action Buttons -->
+                    <div class="form-actions justify-content-between">
+                        <a asp-page="./Index" class="cancel-btn">
+                            <i class="bi bi-arrow-left"></i> Cancel
+                        </a>
+                        <button type="submit" class="submit-btn">
+                            <i class="bi bi-plus-circle"></i> Create Project
+                        </button>
+                    </div>
+                </form>
             </div>
         </div>
     </div>
 </div>
 
+@section Styles {
 <style>
-.icon-option {
-    width: 50px;
-    height: 50px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 1.2rem;
-}
-
-.icon-option:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 8px rgba(0,0,0,0.1);
-}
-
-.project-preview {
-    background-color: #f8f9fa;
-    border: 2px dashed #dee2e6;
-}
-
-.form-control-color {
-    border-radius: 0.375rem;
-    border: 1px solid #ced4da;
-}
-</style>
-
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-    const nameInput = document.getElementById('Name');
-    const descriptionInput = document.getElementById('Description');
-    const colorInput = document.querySelector('input[name="Color"]');
-    const colorTextInput = document.getElementById('ColorText');
-    const iconInputs = document.querySelectorAll('input[name="Icon"]');
-    
-    const previewName = document.getElementById('preview-name');
-    const previewDescription = document.getElementById('preview-description');
-    const previewIcon = document.getElementById('preview-icon');
-    
-    // Update preview on input changes
-    function updatePreview() {
-        // Update name
-        previewName.textContent = nameInput.value || 'Project Name';
-        
-        // Update description
-        previewDescription.textContent = descriptionInput.value || 'Project description will appear here...';
-        
-        // Update color
-        const colorValue = colorInput.value;
-        previewIcon.style.color = colorValue;
-        
-        // Update icon
-        const selectedIcon = document.querySelector('input[name="Icon"]:checked');
-        if (selectedIcon) {
-            previewIcon.className = `bi bi-${selectedIcon.value}`;
-        }
+    /* Page-specific bits that build on components.css (theme-aware) */
+    .color-swatch {
+        width: 48px;
+        height: 46px;
+        padding: 4px;
+        border: 1px solid var(--border-color);
+        border-radius: 10px;
+        background: var(--surface-secondary);
+        cursor: pointer;
     }
-    
-    // Sync color inputs
-    colorInput.addEventListener('input', function() {
-        colorTextInput.value = this.value;
-        updatePreview();
-    });
-    
-    colorTextInput.addEventListener('input', function() {
-        colorInput.value = this.value;
-        updatePreview();
-    });
-    
-    // Listen for input changes
-    nameInput.addEventListener('input', updatePreview);
-    descriptionInput.addEventListener('input', updatePreview);
-    iconInputs.forEach(input => {
-        input.addEventListener('change', updatePreview);
-    });
-    
-    // Initial preview update
-    updatePreview();
-});
-</script>
+
+    .icon-selection { display: flex; flex-wrap: wrap; gap: 0.5rem; }
+
+    .icon-option {
+        width: 50px;
+        height: 50px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 1.2rem;
+        border: 1px solid var(--border-color);
+        border-radius: 10px;
+        background: var(--surface-secondary);
+        color: var(--text-secondary);
+        cursor: pointer;
+        transition: all 0.2s ease;
+    }
+
+    .icon-option:hover { transform: translateY(-2px); box-shadow: var(--shadow-md); }
+
+    .btn-check:checked + .icon-option {
+        border-color: var(--accent-color);
+        color: var(--accent-color);
+        background: var(--accent-light);
+    }
+
+    .project-preview {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+        padding: 1.25rem;
+        background: var(--surface-secondary);
+        border: 2px dashed var(--border-color);
+        border-radius: 12px;
+    }
+
+    .project-preview h5 { color: var(--text-primary); }
+</style>
+}
 
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />
-} 
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            const nameInput = document.getElementById('Name');
+            const descriptionInput = document.getElementById('Description');
+            const colorInput = document.querySelector('input[name="Color"]');
+            const colorTextInput = document.getElementById('ColorText');
+            const iconInputs = document.querySelectorAll('input[name="Icon"]');
+
+            const previewName = document.getElementById('preview-name');
+            const previewDescription = document.getElementById('preview-description');
+            const previewIcon = document.getElementById('preview-icon');
+
+            function updatePreview() {
+                previewName.textContent = nameInput.value || 'Project Name';
+                previewDescription.textContent = descriptionInput.value || 'Project description will appear here...';
+                previewIcon.style.color = colorInput.value;
+                const selectedIcon = document.querySelector('input[name="Icon"]:checked');
+                if (selectedIcon) {
+                    previewIcon.className = `bi bi-${selectedIcon.value}`;
+                }
+            }
+
+            colorInput.addEventListener('input', function () {
+                colorTextInput.value = this.value;
+                updatePreview();
+            });
+            colorTextInput.addEventListener('input', function () {
+                colorInput.value = this.value;
+                updatePreview();
+            });
+            nameInput.addEventListener('input', updatePreview);
+            descriptionInput.addEventListener('input', updatePreview);
+            iconInputs.forEach(input => input.addEventListener('change', updatePreview));
+
+            updatePreview();
+        });
+    </script>
+}

--- a/src/DocFlowHub.Web/Pages/Projects/Edit.cshtml
+++ b/src/DocFlowHub.Web/Pages/Projects/Edit.cshtml
@@ -4,258 +4,184 @@
     ViewData["Title"] = "Edit Project";
 }
 
-<div class="container page-transition">
+<div class="page-container page-transition">
     <!-- Breadcrumb -->
-    <nav aria-label="breadcrumb" class="mb-4">
-        <ol class="breadcrumb">
-            <li class="breadcrumb-item"><a asp-page="/Index">Home</a></li>
-            <li class="breadcrumb-item"><a asp-page="./Index">Projects</a></li>
-            <li class="breadcrumb-item"><a asp-page="./Details" asp-route-id="@Model.Id">@Model.Name</a></li>
-            <li class="breadcrumb-item active" aria-current="page">Edit</li>
+    <nav aria-label="breadcrumb">
+        <ol class="breadcrumb-modern">
+            <li><a asp-page="/Index">Home</a></li>
+            <li class="breadcrumb-sep">/</li>
+            <li><a asp-page="./Index">Projects</a></li>
+            <li class="breadcrumb-sep">/</li>
+            <li><a asp-page="./Details" asp-route-id="@Model.Id">@Model.Name</a></li>
+            <li class="breadcrumb-sep">/</li>
+            <li class="active" aria-current="page">Edit</li>
         </ol>
     </nav>
 
+    <!-- Page Header -->
+    <div class="page-header">
+        <h1 class="page-title">
+            <div class="page-icon">✏️</div>
+            Edit Project
+        </h1>
+        <p class="page-subtitle">Update your project details and appearance</p>
+    </div>
+
+    @if (!string.IsNullOrEmpty(Model.ErrorMessage))
+    {
+        <div class="validation-summary" style="display:block;">
+            <i class="bi bi-exclamation-triangle-fill me-2"></i>@Model.ErrorMessage
+        </div>
+    }
+
     <div class="row justify-content-center">
-        <div class="col-lg-8">
-            <div class="card shadow-sm">
-                <div class="card-header bg-primary text-white">
-                    <h1 class="card-title mb-0 h4">
-                        <i class="bi bi-pencil me-2"></i>
-                        Edit Project
-                    </h1>
-                </div>
-                <div class="card-body">
-                    @if (!string.IsNullOrEmpty(Model.ErrorMessage))
-                    {
-                        <div class="alert alert-danger alert-dismissible fade show" role="alert">
-                            <i class="bi bi-exclamation-triangle-fill me-2"></i>
-                            @Model.ErrorMessage
-                            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-                        </div>
-                    }
+        <div class="col-lg-9">
+            <div class="form-card">
+                <form method="post" id="edit-project-form">
+                    <input type="hidden" asp-for="Id" />
+                    <div asp-validation-summary="ModelOnly" class="validation-summary"></div>
 
-                    <form method="post" id="edit-project-form">
-                        <input type="hidden" asp-for="Id" />
-                        
-                        <!-- Project Basic Information -->
-                        <div class="row">
-                            <div class="col-md-8">
-                                <div class="mb-3">
-                                    <label asp-for="Name" class="form-label fw-bold">
-                                        <i class="bi bi-card-text me-1"></i> Project Name *
-                                    </label>
-                                    <input asp-for="Name" class="form-control" placeholder="Enter project name..." autofocus />
-                                    <span asp-validation-for="Name" class="text-danger"></span>
-                                </div>
-                            </div>
-                            
-                            <div class="col-md-4">
-                                <div class="mb-3">
-                                    <label asp-for="Color" class="form-label fw-bold">
-                                        <i class="bi bi-palette me-1"></i> Project Color
-                                    </label>
-                                    <div class="d-flex align-items-center">
-                                        <input asp-for="Color" type="color" class="form-control form-control-color me-2" style="width: 50px; height: 38px;" />
-                                        <input type="text" id="ColorText" name="ColorText" value="@Model.Color" class="form-control flex-grow-1" placeholder="#0d6efd" />
-                                    </div>
-                                    <span asp-validation-for="Color" class="text-danger"></span>
-                                </div>
-                            </div>
-                        </div>
-
-                        <div class="mb-3">
-                            <label asp-for="Description" class="form-label fw-bold">
-                                <i class="bi bi-card-list me-1"></i> Description
+                    <div class="form-row">
+                        <div class="form-group full-width" style="grid-column: span 1;">
+                            <label asp-for="Name" class="form-label">
+                                <i class="bi bi-card-text"></i> Project Name *
                             </label>
-                            <textarea asp-for="Description" class="form-control" rows="3" 
-                                      placeholder="Enter a brief description of your project..."></textarea>
-                            <span asp-validation-for="Description" class="text-danger"></span>
+                            <input asp-for="Name" class="form-input" placeholder="Enter project name..." autofocus />
+                            <span asp-validation-for="Name" class="validation-message"></span>
                         </div>
 
-                        <!-- Icon Selection -->
-                        <div class="mb-4">
-                            <label asp-for="Icon" class="form-label fw-bold">
-                                <i class="bi bi-emoji-smile me-1"></i> Project Icon
+                        <div class="form-group">
+                            <label asp-for="Color" class="form-label">
+                                <i class="bi bi-palette"></i> Project Color
                             </label>
-                            <div class="icon-selection">
-                                <div class="row g-2">
-                                    <div class="col-auto">
-                                        <input type="radio" class="btn-check" name="Icon" value="kanban" id="icon-kanban" 
-                                               @(Model.Icon == "kanban" ? "checked" : "") />
-                                        <label class="btn btn-outline-secondary icon-option" for="icon-kanban">
-                                            <i class="bi bi-kanban"></i>
-                                        </label>
-                                    </div>
-                                    <div class="col-auto">
-                                        <input type="radio" class="btn-check" name="Icon" value="folder" id="icon-folder"
-                                               @(Model.Icon == "folder" ? "checked" : "") />
-                                        <label class="btn btn-outline-secondary icon-option" for="icon-folder">
-                                            <i class="bi bi-folder"></i>
-                                        </label>
-                                    </div>
-                                    <div class="col-auto">
-                                        <input type="radio" class="btn-check" name="Icon" value="briefcase" id="icon-briefcase"
-                                               @(Model.Icon == "briefcase" ? "checked" : "") />
-                                        <label class="btn btn-outline-secondary icon-option" for="icon-briefcase">
-                                            <i class="bi bi-briefcase"></i>
-                                        </label>
-                                    </div>
-                                    <div class="col-auto">
-                                        <input type="radio" class="btn-check" name="Icon" value="building" id="icon-building"
-                                               @(Model.Icon == "building" ? "checked" : "") />
-                                        <label class="btn btn-outline-secondary icon-option" for="icon-building">
-                                            <i class="bi bi-building"></i>
-                                        </label>
-                                    </div>
-                                    <div class="col-auto">
-                                        <input type="radio" class="btn-check" name="Icon" value="diagram-3" id="icon-diagram"
-                                               @(Model.Icon == "diagram-3" ? "checked" : "") />
-                                        <label class="btn btn-outline-secondary icon-option" for="icon-diagram">
-                                            <i class="bi bi-diagram-3"></i>
-                                        </label>
-                                    </div>
-                                    <div class="col-auto">
-                                        <input type="radio" class="btn-check" name="Icon" value="gear" id="icon-gear"
-                                               @(Model.Icon == "gear" ? "checked" : "") />
-                                        <label class="btn btn-outline-secondary icon-option" for="icon-gear">
-                                            <i class="bi bi-gear"></i>
-                                        </label>
-                                    </div>
-                                    <div class="col-auto">
-                                        <input type="radio" class="btn-check" name="Icon" value="lightbulb" id="icon-lightbulb"
-                                               @(Model.Icon == "lightbulb" ? "checked" : "") />
-                                        <label class="btn btn-outline-secondary icon-option" for="icon-lightbulb">
-                                            <i class="bi bi-lightbulb"></i>
-                                        </label>
-                                    </div>
-                                    <div class="col-auto">
-                                        <input type="radio" class="btn-check" name="Icon" value="star" id="icon-star"
-                                               @(Model.Icon == "star" ? "checked" : "") />
-                                        <label class="btn btn-outline-secondary icon-option" for="icon-star">
-                                            <i class="bi bi-star"></i>
-                                        </label>
-                                    </div>
-                                </div>
-                                <span asp-validation-for="Icon" class="text-danger"></span>
+                            <div class="d-flex align-items-center gap-2">
+                                <input asp-for="Color" type="color" class="color-swatch" />
+                                <input type="text" id="ColorText" name="ColorText" value="@Model.Color" class="form-input flex-grow-1" placeholder="#0d6efd" />
+                            </div>
+                            <span asp-validation-for="Color" class="validation-message"></span>
+                        </div>
+                    </div>
+
+                    <div class="form-group full-width">
+                        <label asp-for="Description" class="form-label">
+                            <i class="bi bi-card-list"></i> Description
+                        </label>
+                        <textarea asp-for="Description" class="form-textarea" rows="3"
+                                  placeholder="Enter a brief description of your project..."></textarea>
+                        <span asp-validation-for="Description" class="validation-message"></span>
+                    </div>
+
+                    <!-- Icon Selection -->
+                    <div class="form-group full-width">
+                        <label asp-for="Icon" class="form-label">
+                            <i class="bi bi-emoji-smile"></i> Project Icon
+                        </label>
+                        <div class="icon-selection">
+                            @foreach (var value in new[] { "kanban", "folder", "briefcase", "building", "diagram-3", "gear", "lightbulb", "star" })
+                            {
+                                <input type="radio" class="btn-check" name="Icon" value="@value" id="icon-@value" checked="@(Model.Icon == value)" />
+                                <label class="icon-option" for="icon-@value">
+                                    <i class="bi bi-@value"></i>
+                                </label>
+                            }
+                        </div>
+                        <span asp-validation-for="Icon" class="validation-message"></span>
+                    </div>
+
+                    <!-- Project Preview -->
+                    <div class="form-group full-width">
+                        <label class="form-label"><i class="bi bi-eye"></i> Preview</label>
+                        <div class="project-preview">
+                            <div class="project-icon">
+                                <i id="preview-icon" class="bi bi-@(Model.Icon ?? "kanban")" style="color:@(Model.Color ?? "#0d6efd");font-size:2rem;"></i>
+                            </div>
+                            <div>
+                                <h5 class="mb-1" id="preview-name">@(Model.Name ?? "Project Name")</h5>
+                                <p class="text-muted mb-0" id="preview-description">@(Model.Description ?? "Project description will appear here...")</p>
                             </div>
                         </div>
+                    </div>
 
-                        <!-- Project Preview -->
-                        <div class="mb-4">
-                            <label class="form-label fw-bold">
-                                <i class="bi bi-eye me-1"></i> Preview
-                            </label>
-                            <div class="project-preview card">
-                                <div class="card-body">
-                                    <div class="d-flex align-items-center">
-                                        <div class="project-icon me-3">
-                                            <i id="preview-icon" class="bi bi-@(Model.Icon ?? "kanban")" style="color: @(Model.Color ?? "#0d6efd"); font-size: 2rem;"></i>
-                                        </div>
-                                        <div>
-                                            <h5 class="card-title mb-1" id="preview-name">@(Model.Name ?? "Project Name")</h5>
-                                            <p class="card-text text-muted mb-0" id="preview-description">@(Model.Description ?? "Project description will appear here...")</p>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-
-                        <!-- Action Buttons -->
-                        <div class="d-flex justify-content-between">
-                            <a asp-page="./Details" asp-route-id="@Model.Id" class="btn btn-secondary">
-                                <i class="bi bi-arrow-left me-1"></i> Cancel
-                            </a>
-                            <button type="submit" class="btn btn-primary">
-                                <i class="bi bi-check-circle me-1"></i> Save Changes
-                            </button>
-                        </div>
-                    </form>
-                </div>
+                    <!-- Action Buttons -->
+                    <div class="form-actions justify-content-between">
+                        <a asp-page="./Details" asp-route-id="@Model.Id" class="cancel-btn">
+                            <i class="bi bi-arrow-left"></i> Cancel
+                        </a>
+                        <button type="submit" class="submit-btn">
+                            <i class="bi bi-check-circle"></i> Save Changes
+                        </button>
+                    </div>
+                </form>
             </div>
         </div>
     </div>
 </div>
 
+@section Styles {
 <style>
-.icon-option {
-    width: 50px;
-    height: 50px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 1.2rem;
-}
-
-.icon-option:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 8px rgba(0,0,0,0.1);
-}
-
-.project-preview {
-    background-color: #f8f9fa;
-    border: 2px dashed #dee2e6;
-}
-
-.form-control-color {
-    border-radius: 0.375rem;
-    border: 1px solid #ced4da;
-}
-</style>
-
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-    const nameInput = document.getElementById('Name');
-    const descriptionInput = document.getElementById('Description');
-    const colorInput = document.querySelector('input[name="Color"]');
-    const colorTextInput = document.getElementById('ColorText');
-    const iconInputs = document.querySelectorAll('input[name="Icon"]');
-    
-    const previewName = document.getElementById('preview-name');
-    const previewDescription = document.getElementById('preview-description');
-    const previewIcon = document.getElementById('preview-icon');
-    
-    // Update preview on input changes
-    function updatePreview() {
-        // Update name
-        previewName.textContent = nameInput.value || 'Project Name';
-        
-        // Update description
-        previewDescription.textContent = descriptionInput.value || 'Project description will appear here...';
-        
-        // Update color
-        const colorValue = colorInput.value;
-        previewIcon.style.color = colorValue;
-        
-        // Update icon
-        const selectedIcon = document.querySelector('input[name="Icon"]:checked');
-        if (selectedIcon) {
-            previewIcon.className = `bi bi-${selectedIcon.value}`;
-        }
+    .color-swatch {
+        width: 48px; height: 46px; padding: 4px;
+        border: 1px solid var(--border-color); border-radius: 10px;
+        background: var(--surface-secondary); cursor: pointer;
     }
-    
-    // Sync color inputs
-    colorInput.addEventListener('input', function() {
-        colorTextInput.value = this.value;
-        updatePreview();
-    });
-    
-    colorTextInput.addEventListener('input', function() {
-        colorInput.value = this.value;
-        updatePreview();
-    });
-    
-    // Listen for input changes
-    nameInput.addEventListener('input', updatePreview);
-    descriptionInput.addEventListener('input', updatePreview);
-    iconInputs.forEach(input => {
-        input.addEventListener('change', updatePreview);
-    });
-    
-    // Initial preview update
-    updatePreview();
-});
-</script>
+    .icon-selection { display: flex; flex-wrap: wrap; gap: 0.5rem; }
+    .icon-option {
+        width: 50px; height: 50px;
+        display: flex; align-items: center; justify-content: center;
+        font-size: 1.2rem;
+        border: 1px solid var(--border-color); border-radius: 10px;
+        background: var(--surface-secondary); color: var(--text-secondary);
+        cursor: pointer; transition: all 0.2s ease;
+    }
+    .icon-option:hover { transform: translateY(-2px); box-shadow: var(--shadow-md); }
+    .btn-check:checked + .icon-option {
+        border-color: var(--accent-color); color: var(--accent-color); background: var(--accent-light);
+    }
+    .project-preview {
+        display: flex; align-items: center; gap: 1rem; padding: 1.25rem;
+        background: var(--surface-secondary); border: 2px dashed var(--border-color); border-radius: 12px;
+    }
+    .project-preview h5 { color: var(--text-primary); }
+</style>
+}
 
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />
-} 
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            const nameInput = document.getElementById('Name');
+            const descriptionInput = document.getElementById('Description');
+            const colorInput = document.querySelector('input[name="Color"]');
+            const colorTextInput = document.getElementById('ColorText');
+            const iconInputs = document.querySelectorAll('input[name="Icon"]');
+
+            const previewName = document.getElementById('preview-name');
+            const previewDescription = document.getElementById('preview-description');
+            const previewIcon = document.getElementById('preview-icon');
+
+            function updatePreview() {
+                previewName.textContent = nameInput.value || 'Project Name';
+                previewDescription.textContent = descriptionInput.value || 'Project description will appear here...';
+                previewIcon.style.color = colorInput.value;
+                const selectedIcon = document.querySelector('input[name="Icon"]:checked');
+                if (selectedIcon) {
+                    previewIcon.className = `bi bi-${selectedIcon.value}`;
+                }
+            }
+
+            colorInput.addEventListener('input', function () {
+                colorTextInput.value = this.value;
+                updatePreview();
+            });
+            colorTextInput.addEventListener('input', function () {
+                colorInput.value = this.value;
+                updatePreview();
+            });
+            nameInput.addEventListener('input', updatePreview);
+            descriptionInput.addEventListener('input', updatePreview);
+            iconInputs.forEach(input => input.addEventListener('change', updatePreview));
+
+            updatePreview();
+        });
+    </script>
+}

--- a/src/DocFlowHub.Web/Pages/Settings/AI.cshtml.cs
+++ b/src/DocFlowHub.Web/Pages/Settings/AI.cshtml.cs
@@ -31,7 +31,7 @@ public class AIModel : PageModel
     public class InputModel
     {
         [Display(Name = "Preferred AI Model")]
-        public Core.Models.AI.AIModel PreferredModel { get; set; } = Core.Models.AI.AIModel.Gpt4oMini;
+        public Core.Models.AI.AIModel PreferredModel { get; set; } = Core.Models.AI.AIModelHelper.GetDefaultModel();
 
         [Display(Name = "Custom OpenAI API Key")]
         [StringLength(500, ErrorMessage = "API key cannot exceed 500 characters")]
@@ -201,7 +201,7 @@ public class AIModel : PageModel
                         name = m.Model.ToApiString(), 
                         displayName = m.Name, 
                         description = m.Description,
-                        isRecommended = m.Model == Core.Models.AI.AIModel.Gpt4oMini || m.Model == Core.Models.AI.AIModel.Gpt4o
+                        isRecommended = m.Model == Core.Models.AI.AIModel.ClaudeHaiku45 || m.Model == Core.Models.AI.AIModel.ClaudeSonnet5
                     })
                     .ToList();
 

--- a/src/DocFlowHub.Web/Pages/Shared/_Layout.cshtml
+++ b/src/DocFlowHub.Web/Pages/Shared/_Layout.cshtml
@@ -26,6 +26,7 @@
     <!-- Custom CSS -->
     <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
     <link rel="stylesheet" href="~/css/ux-enhancements.css" asp-append-version="true" />
+    <link rel="stylesheet" href="~/css/components.css" asp-append-version="true" />
     <link rel="stylesheet" href="~/DocFlowHub.Web.styles.css" asp-append-version="true" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
     @await RenderSectionAsync("Styles", required: false)

--- a/src/DocFlowHub.Web/Pages/Teams/Create.cshtml
+++ b/src/DocFlowHub.Web/Pages/Teams/Create.cshtml
@@ -4,96 +4,109 @@
     ViewData["Title"] = "Create Team";
 }
 
-<div class="container">
+<div class="page-container page-transition">
+    <!-- Breadcrumb -->
+    <nav aria-label="breadcrumb">
+        <ol class="breadcrumb-modern">
+            <li><a asp-page="/Index">Home</a></li>
+            <li class="breadcrumb-sep">/</li>
+            <li><a asp-page="./Index">Teams</a></li>
+            <li class="breadcrumb-sep">/</li>
+            <li class="active" aria-current="page">Create</li>
+        </ol>
+    </nav>
+
+    <!-- Page Header -->
+    <div class="page-header">
+        <h1 class="page-title">
+            <div class="page-icon">👥</div>
+            Create New Team
+        </h1>
+        <p class="page-subtitle">Set up a team to collaborate on shared documents</p>
+    </div>
+
+    @if (!string.IsNullOrEmpty(Model.ErrorMessage))
+    {
+        <div class="validation-summary" style="display:block;">
+            <i class="bi bi-exclamation-triangle-fill me-2"></i>@Model.ErrorMessage
+        </div>
+    }
+
     <div class="row justify-content-center">
-        <div class="col-md-8">
-            <div class="card">
-                <div class="card-header bg-primary text-white">
-                    <h4 class="mb-0">
-                        <i class="bi bi-plus-circle me-2"></i>
-                        Create New Team
-                    </h4>
-                </div>
-                <div class="card-body">
-                    @if (!string.IsNullOrEmpty(Model.ErrorMessage))
-                    {
-                        <div class="alert alert-danger" role="alert">
-                            <i class="bi bi-exclamation-triangle me-2"></i>
-                            @Model.ErrorMessage
-                        </div>
-                    }
+        <div class="col-lg-8">
+            <div class="form-card">
+                <form method="post" id="createTeamForm">
+                    <div asp-validation-summary="ModelOnly" class="validation-summary"></div>
 
-                    <form method="post" id="createTeamForm">
-                        <div asp-validation-summary="ModelOnly" class="text-danger mb-3"></div>
-                        
-                        <div class="mb-4">
-                            <label asp-for="Name" class="form-label">
-                                <i class="bi bi-people me-1"></i>
-                                Team Name <span class="text-danger">*</span>
-                            </label>
-                            <input asp-for="Name" class="form-control" placeholder="Enter team name" maxlength="100" />
-                            <span asp-validation-for="Name" class="text-danger"></span>
-                            <div class="form-text">
-                                Choose a descriptive name for your team (3-100 characters)
-                            </div>
-                        </div>
+                    <div class="form-group full-width">
+                        <label asp-for="Name" class="form-label">
+                            <i class="bi bi-people"></i> Team Name *
+                        </label>
+                        <input asp-for="Name" class="form-input" placeholder="Enter team name" maxlength="100" />
+                        <span asp-validation-for="Name" class="validation-message"></span>
+                        <div class="form-hint">Choose a descriptive name for your team (3-100 characters)</div>
+                    </div>
 
-                        <div class="mb-4">
-                            <label asp-for="Description" class="form-label">
-                                <i class="bi bi-card-text me-1"></i>
-                                Description
-                            </label>
-                            <textarea asp-for="Description" class="form-control" rows="4" 
-                                      placeholder="Describe the purpose and goals of your team..." maxlength="500"></textarea>
-                            <span asp-validation-for="Description" class="text-danger"></span>
-                            <div class="form-text">
-                                Optional description to help team members understand the team's purpose (max 500 characters)
-                            </div>
-                        </div>
+                    <div class="form-group full-width">
+                        <label asp-for="Description" class="form-label">
+                            <i class="bi bi-card-text"></i> Description
+                        </label>
+                        <textarea asp-for="Description" class="form-textarea" rows="4"
+                                  placeholder="Describe the purpose and goals of your team..." maxlength="500"></textarea>
+                        <span asp-validation-for="Description" class="validation-message"></span>
+                        <div class="form-hint">Optional — helps team members understand the team's purpose (max 500 characters)</div>
+                    </div>
 
-                        <div class="mb-4">
-                            <div class="bg-light p-3 rounded">
-                                <h6 class="mb-2">
-                                    <i class="bi bi-info-circle text-primary me-1"></i>
-                                    Team Information
-                                </h6>
-                                <ul class="mb-0 small text-muted">
-                                    <li>You will be the team owner and can manage all team settings</li>
-                                    <li>You can invite members by email after creating the team</li>
-                                    <li>Team members can view and collaborate on shared documents</li>
-                                    <li>You can modify team details and member permissions anytime</li>
-                                </ul>
-                            </div>
-                        </div>
+                    <div class="info-box">
+                        <h6><i class="bi bi-info-circle"></i> Team Information</h6>
+                        <ul>
+                            <li>You will be the team owner and can manage all team settings</li>
+                            <li>You can invite members by email after creating the team</li>
+                            <li>Team members can view and collaborate on shared documents</li>
+                            <li>You can modify team details and member permissions anytime</li>
+                        </ul>
+                    </div>
 
-                        <div class="d-flex justify-content-between">
-                            <a asp-page="./Index" class="btn btn-secondary">
-                                <i class="bi bi-arrow-left me-1"></i>
-                                Back to Teams
-                            </a>
-                            <button type="submit" class="btn btn-primary" id="submitBtn">
-                                <span class="btn-text">
-                                    <i class="bi bi-plus-circle me-1"></i>
-                                    Create Team
-                                </span>
-                                <span class="btn-loading d-none">
-                                    <i class="bi bi-arrow-clockwise spin me-1"></i>
-                                    Creating...
-                                </span>
-                            </button>
-                        </div>
-                    </form>
-                </div>
+                    <div class="form-actions justify-content-between">
+                        <a asp-page="./Index" class="cancel-btn">
+                            <i class="bi bi-arrow-left"></i> Back to Teams
+                        </a>
+                        <button type="submit" class="submit-btn" id="submitBtn">
+                            <span class="btn-text"><i class="bi bi-plus-circle"></i> Create Team</span>
+                            <span class="btn-loading d-none"><i class="bi bi-arrow-clockwise spin"></i> Creating...</span>
+                        </button>
+                    </div>
+                </form>
             </div>
         </div>
     </div>
 </div>
 
+@section Styles {
+<style>
+    .info-box {
+        background: var(--surface-secondary);
+        border: 1px solid var(--border-color);
+        border-radius: 12px;
+        padding: 1.25rem;
+        margin-bottom: 1.5rem;
+    }
+    .info-box h6 {
+        display: flex; align-items: center; gap: 0.5rem;
+        color: var(--text-primary); font-weight: 600; margin-bottom: 0.5rem;
+    }
+    .info-box h6 i { color: var(--accent-color); }
+    .info-box ul { margin: 0; padding-left: 1.25rem; color: var(--text-secondary); font-size: 0.875rem; }
+    .info-box li { margin-bottom: 0.25rem; }
+    .spin { animation: spin 1s linear infinite; }
+    @@keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+</style>
+}
+
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />
-    
     <script>
-        document.addEventListener('DOMContentLoaded', function() {
+        document.addEventListener('DOMContentLoaded', function () {
             const form = document.getElementById('createTeamForm');
             const submitBtn = document.getElementById('submitBtn');
             const btnText = submitBtn.querySelector('.btn-text');
@@ -101,39 +114,24 @@
             const nameInput = document.querySelector('input[name="Name"]');
             const descInput = document.querySelector('textarea[name="Description"]');
 
-            // Character counter for description
             if (descInput) {
                 const maxLength = 500;
                 const counter = document.createElement('div');
-                counter.className = 'form-text text-end';
+                counter.className = 'form-hint text-end';
                 counter.innerHTML = `<span id="charCount">0</span>/${maxLength} characters`;
                 descInput.parentNode.appendChild(counter);
-
                 const charCountSpan = document.getElementById('charCount');
-                
-                descInput.addEventListener('input', function() {
-                    const currentLength = this.value.length;
-                    charCountSpan.textContent = currentLength;
-                    
-                    if (currentLength > maxLength * 0.9) {
-                        charCountSpan.parentNode.classList.add('text-warning');
-                    } else {
-                        charCountSpan.parentNode.classList.remove('text-warning');
-                    }
+                descInput.addEventListener('input', function () {
+                    charCountSpan.textContent = this.value.length;
                 });
-
-                // Initialize counter
                 descInput.dispatchEvent(new Event('input'));
             }
 
-            // Form submission loading state
-            form.addEventListener('submit', function() {
+            form.addEventListener('submit', function () {
                 if (form.checkValidity()) {
                     submitBtn.disabled = true;
                     btnText.classList.add('d-none');
                     btnLoading.classList.remove('d-none');
-                    
-                    // Re-enable after timeout as fallback
                     setTimeout(() => {
                         submitBtn.disabled = false;
                         btnText.classList.remove('d-none');
@@ -142,56 +140,7 @@
                 }
             });
 
-            // Auto-focus on team name input
-            if (nameInput) {
-                nameInput.focus();
-            }
-
-            // Real-time validation feedback
-            nameInput?.addEventListener('input', function() {
-                const value = this.value.trim();
-                const isValid = value.length >= 3 && value.length <= 100;
-                
-                this.classList.toggle('is-valid', isValid && value.length > 0);
-                this.classList.toggle('is-invalid', !isValid && value.length > 0);
-            });
+            if (nameInput) { nameInput.focus(); }
         });
     </script>
-    
-    <style>
-        .spin {
-            animation: spin 1s linear infinite;
-        }
-        
-        @@keyframes spin {
-            from { transform: rotate(0deg); }
-            to { transform: rotate(360deg); }
-        }
-        
-        .card {
-            box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-            border: none;
-        }
-        
-        .form-control:focus {
-            border-color: #007bff;
-            box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25);
-        }
-        
-        .btn-primary {
-            background: linear-gradient(45deg, #007bff, #0056b3);
-            border: none;
-            transition: all 0.3s ease;
-        }
-        
-        .btn-primary:hover:not(:disabled) {
-            transform: translateY(-1px);
-            box-shadow: 0 4px 8px rgba(0, 123, 255, 0.3);
-        }
-        
-        .bg-light {
-            background-color: #f8f9fa !important;
-            border: 1px solid #e9ecef;
-        }
-    </style>
-} 
+}

--- a/src/DocFlowHub.Web/Pages/Teams/Edit.cshtml
+++ b/src/DocFlowHub.Web/Pages/Teams/Edit.cshtml
@@ -143,12 +143,7 @@
 
 @section Styles {
 <style>
-    .section-heading {
-        display: flex; align-items: center; gap: 0.5rem;
-        color: var(--text-primary); font-weight: 600; margin-bottom: 1.25rem;
-    }
-    .section-heading i { color: var(--accent-color); }
-    .section-heading.text-danger, .section-heading.text-danger i { color: var(--error-color); }
+    /* .section-heading and its .text-danger variant live in components.css */
     .danger-zone { border-color: rgba(239, 68, 68, 0.4); }
     .info-line { display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.75rem; font-size: 0.9rem; color: var(--text-primary); }
     .info-line i { color: var(--accent-color); }

--- a/src/DocFlowHub.Web/Pages/Teams/Edit.cshtml
+++ b/src/DocFlowHub.Web/Pages/Teams/Edit.cshtml
@@ -4,210 +4,123 @@
     ViewData["Title"] = $"Edit Team - {Model.TeamName}";
 }
 
-<div class="container-fluid py-4 page-transition">
+<div class="page-container page-transition">
     <!-- Breadcrumb -->
-    <div class="row mb-4">
-        <div class="col-12">
-            <nav aria-label="breadcrumb">
-                <ol class="breadcrumb">
-                    <li class="breadcrumb-item">
-                        <a asp-page="/Index" class="text-decoration-none">
-                            <i class="bi bi-house me-1"></i>Dashboard
-                        </a>
-                    </li>
-                    <li class="breadcrumb-item">
-                        <a asp-page="/Teams/Index" class="text-decoration-none">
-                            <i class="bi bi-people me-1"></i>Teams
-                        </a>
-                    </li>
-                    <li class="breadcrumb-item">
-                        <a asp-page="/Teams/Details" asp-route-id="@Model.TeamId" class="text-decoration-none">
-                            @Model.TeamName
-                        </a>
-                    </li>
-                    <li class="breadcrumb-item active" aria-current="page">Edit</li>
-                </ol>
-            </nav>
-        </div>
-    </div>
+    <nav aria-label="breadcrumb">
+        <ol class="breadcrumb-modern">
+            <li><a asp-page="/Index">Dashboard</a></li>
+            <li class="breadcrumb-sep">/</li>
+            <li><a asp-page="/Teams/Index">Teams</a></li>
+            <li class="breadcrumb-sep">/</li>
+            <li><a asp-page="/Teams/Details" asp-route-id="@Model.TeamId">@Model.TeamName</a></li>
+            <li class="breadcrumb-sep">/</li>
+            <li class="active" aria-current="page">Edit</li>
+        </ol>
+    </nav>
 
     <!-- Page Header -->
-    <div class="row mb-4">
-        <div class="col-12">
-            <div class="d-flex justify-content-between align-items-center">
-                <div>
-                    <h1 class="h3 mb-1">
-                        <i class="bi bi-pencil-square me-2 text-primary"></i>
-                        Edit Team
-                    </h1>
-                    <p class="text-muted mb-0">Update team information or delete the team</p>
-                </div>
-                <div>
-                    <a asp-page="/Teams/Details" asp-route-id="@Model.TeamId" class="btn btn-outline-secondary">
-                        <i class="bi bi-arrow-left me-1"></i>Back to Team
-                    </a>
-                </div>
-            </div>
+    <div class="page-header d-flex justify-content-between align-items-center flex-wrap gap-2">
+        <div>
+            <h1 class="page-title"><div class="page-icon">✏️</div> Edit Team</h1>
+            <p class="page-subtitle">Update team information or delete the team</p>
         </div>
+        <a asp-page="/Teams/Details" asp-route-id="@Model.TeamId" class="cancel-btn">
+            <i class="bi bi-arrow-left"></i> Back to Team
+        </a>
     </div>
 
-    <!-- Status Messages -->
     @if (!string.IsNullOrEmpty(Model.SuccessMessage))
     {
-        <div class="row mb-4">
-            <div class="col-12">
-                <div class="alert alert-success alert-dismissible fade show" role="alert">
-                    <i class="bi bi-check-circle me-2"></i>@Model.SuccessMessage
-                    <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
-                </div>
-            </div>
+        <div class="validation-summary" style="display:block;background:rgba(16,185,129,0.1);border-color:rgba(16,185,129,0.3);color:var(--success-color);">
+            <i class="bi bi-check-circle me-2"></i>@Model.SuccessMessage
         </div>
     }
-
     @if (!string.IsNullOrEmpty(Model.ErrorMessage))
     {
-        <div class="row mb-4">
-            <div class="col-12">
-                <div class="alert alert-danger alert-dismissible fade show" role="alert">
-                    <i class="bi bi-exclamation-circle me-2"></i>@Model.ErrorMessage
-                    <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
-                </div>
-            </div>
+        <div class="validation-summary" style="display:block;">
+            <i class="bi bi-exclamation-circle me-2"></i>@Model.ErrorMessage
         </div>
     }
 
-    <div class="row">
+    <div class="row g-4">
         <!-- Edit Team Form -->
         <div class="col-lg-8">
-            <div class="card border-0 shadow-sm">
-                <div class="card-header bg-transparent border-0 pb-0">
-                    <h5 class="card-title mb-0">
-                        <i class="bi bi-info-circle me-2 text-primary"></i>
-                        Team Information
-                    </h5>
-                    <p class="card-text text-muted mb-0">Update your team's basic information</p>
-                </div>
-                <div class="card-body">
-                    <form method="post" asp-page-handler="Update" class="needs-validation" novalidate>
-                        <input asp-for="TeamId" type="hidden" />
-                        
-                        <div class="mb-4">
-                            <label asp-for="Name" class="form-label">
-                                <i class="bi bi-tag me-1"></i>Team Name
-                            </label>
-                            <input asp-for="Name" class="form-control form-control-lg" 
-                                   placeholder="Enter team name" maxlength="100" required>
-                            <span asp-validation-for="Name" class="text-danger small"></span>
-                            <div class="form-text">
-                                <i class="bi bi-info-circle me-1"></i>
-                                Choose a descriptive name for your team (max 100 characters)
-                            </div>
-                        </div>
+            <div class="form-card">
+                <h5 class="section-heading"><i class="bi bi-info-circle"></i> Team Information</h5>
+                <form method="post" asp-page-handler="Update" class="needs-validation" novalidate>
+                    <input asp-for="TeamId" type="hidden" />
 
-                        <div class="mb-4">
-                            <label asp-for="Description" class="form-label">
-                                <i class="bi bi-card-text me-1"></i>Description
-                            </label>
-                            <textarea asp-for="Description" class="form-control" rows="4" 
-                                      placeholder="Enter team description (optional)" maxlength="500"></textarea>
-                            <span asp-validation-for="Description" class="text-danger small"></span>
-                            <div class="form-text">
-                                <i class="bi bi-info-circle me-1"></i>
-                                Describe the purpose and goals of your team (max 500 characters)
-                            </div>
-                        </div>
+                    <div class="form-group full-width">
+                        <label asp-for="Name" class="form-label"><i class="bi bi-tag"></i> Team Name</label>
+                        <input asp-for="Name" class="form-input" placeholder="Enter team name" maxlength="100" required>
+                        <span asp-validation-for="Name" class="validation-message"></span>
+                        <div class="form-hint">Choose a descriptive name for your team (max 100 characters)</div>
+                    </div>
 
-                        <div class="d-flex gap-2">
-                            <button type="submit" class="btn btn-primary btn-lg loading-btn">
-                                <span class="spinner-border spinner-border-sm d-none me-2" role="status"></span>
-                                <i class="bi bi-check-lg me-1"></i>
-                                <span class="btn-text">Update Team</span>
-                            </button>
-                            <a asp-page="/Teams/Details" asp-route-id="@Model.TeamId" class="btn btn-outline-secondary btn-lg">
-                                <i class="bi bi-x-lg me-1"></i>Cancel
-                            </a>
-                        </div>
-                    </form>
-                </div>
+                    <div class="form-group full-width">
+                        <label asp-for="Description" class="form-label"><i class="bi bi-card-text"></i> Description</label>
+                        <textarea asp-for="Description" class="form-textarea" rows="4"
+                                  placeholder="Enter team description (optional)" maxlength="500"></textarea>
+                        <span asp-validation-for="Description" class="validation-message"></span>
+                        <div class="form-hint">Describe the purpose and goals of your team (max 500 characters)</div>
+                    </div>
+
+                    <div class="form-actions">
+                        <button type="submit" class="submit-btn loading-btn">
+                            <span class="spinner-border spinner-border-sm d-none me-2" role="status"></span>
+                            <i class="bi bi-check-lg"></i>
+                            <span class="btn-text">Update Team</span>
+                        </button>
+                        <a asp-page="/Teams/Details" asp-route-id="@Model.TeamId" class="cancel-btn">
+                            <i class="bi bi-x-lg"></i> Cancel
+                        </a>
+                    </div>
+                </form>
             </div>
         </div>
 
-        <!-- Danger Zone -->
+        <!-- Danger Zone + Info -->
         <div class="col-lg-4">
-            <div class="card border-danger">
-                <div class="card-header bg-danger text-white">
-                    <h5 class="card-title mb-0">
-                        <i class="bi bi-exclamation-triangle me-2"></i>
-                        Danger Zone
-                    </h5>
-                </div>
-                <div class="card-body">
-                    <h6 class="text-danger">Delete Team</h6>
-                    <p class="text-muted small mb-3">
-                        Once you delete a team, there is no going back. This will permanently remove 
-                        the team and all its data including member relationships.
-                    </p>
-                    
-                    <div class="alert alert-warning">
-                        <i class="bi bi-info-circle me-2"></i>
-                        <strong>Warning:</strong> This action cannot be undone.
-                    </div>
-
-                    <button type="button" class="btn btn-danger" data-bs-toggle="modal" data-bs-target="#deleteModal">
-                        <i class="bi bi-trash me-1"></i>Delete Team
-                    </button>
-                </div>
+            <div class="content-card danger-zone">
+                <h5 class="section-heading text-danger"><i class="bi bi-exclamation-triangle"></i> Danger Zone</h5>
+                <p class="text-muted small mb-3">
+                    Once you delete a team, there is no going back. This permanently removes the team and all its
+                    data including member relationships.
+                </p>
+                <button type="button" class="btn-modern-danger" data-bs-toggle="modal" data-bs-target="#deleteModal">
+                    <i class="bi bi-trash"></i> Delete Team
+                </button>
             </div>
 
-            <!-- Team Info -->
-            <div class="card border-0 shadow-sm mt-4">
-                <div class="card-header bg-transparent border-0 pb-0">
-                    <h6 class="card-title mb-0">
-                        <i class="bi bi-info-circle me-2 text-info"></i>
-                        Team Information
-                    </h6>
-                </div>
-                <div class="card-body">
-                    <div class="d-flex align-items-center mb-3">
-                        <i class="bi bi-person-badge text-primary me-2"></i>
-                        <span class="text-muted">Owner:</span>
-                        <span class="ms-2">You</span>
-                    </div>
-                    <div class="d-flex align-items-center">
-                        <i class="bi bi-calendar text-primary me-2"></i>
-                        <span class="text-muted">Team ID:</span>
-                        <span class="ms-2 font-monospace">@Model.TeamId</span>
-                    </div>
-                </div>
+            <div class="content-card mt-3">
+                <h6 class="section-heading"><i class="bi bi-info-circle"></i> Team Information</h6>
+                <div class="info-line"><i class="bi bi-person-badge"></i> <span class="text-muted">Owner:</span> <span>You</span></div>
+                <div class="info-line"><i class="bi bi-hash"></i> <span class="text-muted">Team ID:</span> <span class="font-monospace">@Model.TeamId</span></div>
             </div>
         </div>
     </div>
 </div>
 
-<!-- Delete Confirmation Modal -->
+<!-- Delete Confirmation Modal (Bootstrap) -->
 <div class="modal fade" id="deleteModal" tabindex="-1">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header border-0">
                 <h5 class="modal-title text-danger">
-                    <i class="bi bi-exclamation-triangle me-2"></i>
-                    Confirm Team Deletion
+                    <i class="bi bi-exclamation-triangle me-2"></i>Confirm Team Deletion
                 </h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
             </div>
             <div class="modal-body">
                 <div class="alert alert-danger">
-                    <i class="bi bi-warning me-2"></i>
-                    <strong>This action is irreversible!</strong>
+                    <i class="bi bi-exclamation-octagon me-2"></i><strong>This action is irreversible!</strong>
                 </div>
-                
                 <p>Are you sure you want to delete <strong>"@Model.TeamName"</strong>?</p>
-                
                 <p class="text-muted small">This will:</p>
                 <ul class="text-muted small">
                     <li>Permanently delete the team</li>
                     <li>Remove all team member relationships</li>
-                    <li>Unshare all team documents (documents will remain with original owners)</li>
+                    <li>Unshare all team documents (documents remain with original owners)</li>
                     <li>Remove team from all associated activities</li>
                 </ul>
             </div>
@@ -228,53 +141,60 @@
     </div>
 </div>
 
+@section Styles {
+<style>
+    .section-heading {
+        display: flex; align-items: center; gap: 0.5rem;
+        color: var(--text-primary); font-weight: 600; margin-bottom: 1.25rem;
+    }
+    .section-heading i { color: var(--accent-color); }
+    .section-heading.text-danger, .section-heading.text-danger i { color: var(--error-color); }
+    .danger-zone { border-color: rgba(239, 68, 68, 0.4); }
+    .info-line { display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.75rem; font-size: 0.9rem; color: var(--text-primary); }
+    .info-line i { color: var(--accent-color); }
+    .btn-modern-danger {
+        display: inline-flex; align-items: center; gap: 0.5rem;
+        padding: 0.7rem 1.25rem; border: none; border-radius: 10px;
+        background: linear-gradient(135deg, #ef4444 0%, #dc2626 100%); color: #fff;
+        font-weight: 600; cursor: pointer; transition: all 0.2s ease;
+    }
+    .btn-modern-danger:hover { transform: translateY(-2px); box-shadow: 0 8px 25px rgba(239,68,68,0.3); color: #fff; }
+</style>
+}
+
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />
-    
     <script>
-        document.addEventListener('DOMContentLoaded', function() {
-            // Form validation
-            const forms = document.querySelectorAll('.needs-validation');
-            forms.forEach(form => {
-                form.addEventListener('submit', function(event) {
+        document.addEventListener('DOMContentLoaded', function () {
+            function applyLoading(loadingBtn, label) {
+                if (!loadingBtn) return;
+                const spinner = loadingBtn.querySelector('.spinner-border');
+                const btnText = loadingBtn.querySelector('.btn-text');
+                const icon = loadingBtn.querySelector('.bi');
+                if (spinner) spinner.classList.remove('d-none');
+                if (icon) icon.classList.add('d-none');
+                if (btnText) btnText.textContent = label;
+                loadingBtn.disabled = true;
+            }
+
+            document.querySelectorAll('.needs-validation').forEach(form => {
+                form.addEventListener('submit', function (event) {
                     if (!form.checkValidity()) {
                         event.preventDefault();
                         event.stopPropagation();
                     } else {
-                        // Show loading state
-                        const loadingBtn = form.querySelector('.loading-btn');
-                        if (loadingBtn) {
-                            const spinner = loadingBtn.querySelector('.spinner-border');
-                            const btnText = loadingBtn.querySelector('.btn-text');
-                            const icon = loadingBtn.querySelector('.bi');
-                            
-                            spinner.classList.remove('d-none');
-                            if (icon) icon.classList.add('d-none');
-                            if (btnText) btnText.textContent = 'Updating...';
-                            loadingBtn.disabled = true;
-                        }
+                        applyLoading(form.querySelector('.loading-btn'), 'Updating...');
                     }
                     form.classList.add('was-validated');
                 });
             });
 
-            // Delete form loading state
             const deleteForm = document.querySelector('form[asp-page-handler="Delete"]');
             if (deleteForm) {
-                deleteForm.addEventListener('submit', function() {
-                    const loadingBtn = deleteForm.querySelector('.loading-btn');
-                    if (loadingBtn) {
-                        const spinner = loadingBtn.querySelector('.spinner-border');
-                        const btnText = loadingBtn.querySelector('.btn-text');
-                        const icon = loadingBtn.querySelector('.bi');
-                        
-                        spinner.classList.remove('d-none');
-                        if (icon) icon.classList.add('d-none');
-                        if (btnText) btnText.textContent = 'Deleting...';
-                        loadingBtn.disabled = true;
-                    }
+                deleteForm.addEventListener('submit', function () {
+                    applyLoading(deleteForm.querySelector('.loading-btn'), 'Deleting...');
                 });
             }
         });
     </script>
-} 
+}

--- a/src/DocFlowHub.Web/wwwroot/css/components.css
+++ b/src/DocFlowHub.Web/wwwroot/css/components.css
@@ -1,0 +1,223 @@
+/* DocFlowHub Shared UI Components — Sprint 8 / Workstream D
+ * Reusable, theme-aware building blocks so feature/form/admin pages stop
+ * duplicating the same inline <style> block. All values use the design tokens
+ * defined in themes.css, so light/dark theming is automatic.
+ * Loaded before the page "Styles" section, so any page may still override.
+ */
+
+/* ===== PAGE CONTAINER & HEADER ===== */
+.page-container {
+    padding: 2rem;
+    max-width: 1200px;
+    margin: 0 auto;
+}
+
+.page-header {
+    margin-bottom: 2rem;
+}
+
+.page-header .page-title {
+    font-size: 1.75rem;
+    font-weight: 700;
+    color: var(--text-primary);
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin: 0;
+}
+
+.page-header .page-icon {
+    font-size: 2rem;
+    line-height: 1;
+}
+
+.page-header .page-subtitle {
+    color: var(--text-secondary);
+    margin: 0.5rem 0 0 0;
+    font-size: 1rem;
+}
+
+/* ===== MODERN BREADCRUMB ===== */
+.breadcrumb-modern {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.4rem;
+    list-style: none;
+    padding: 0;
+    margin: 0 0 1.5rem 0;
+    font-size: 0.9rem;
+}
+
+.breadcrumb-modern a {
+    color: var(--text-secondary);
+    text-decoration: none;
+    transition: color 0.2s ease;
+}
+
+.breadcrumb-modern a:hover { color: var(--accent-color); }
+
+.breadcrumb-modern .breadcrumb-sep { color: var(--text-muted); }
+
+.breadcrumb-modern .active { color: var(--text-primary); font-weight: 600; }
+
+/* ===== CARDS ===== */
+.content-card,
+.form-card {
+    background: var(--surface-primary);
+    border: 1px solid var(--border-color);
+    border-radius: 16px;
+    padding: 2rem;
+}
+
+[data-theme="dark"] .content-card,
+[data-theme="dark"] .form-card {
+    background: rgba(45, 45, 45, 0.8);
+}
+
+.content-card.glass,
+.form-card.glass {
+    background: var(--container-bg);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+    box-shadow: var(--shadow-glass);
+}
+
+/* ===== FORMS ===== */
+.form-row {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1.5rem;
+}
+
+.form-group { margin-bottom: 1.5rem; }
+.form-group.full-width { grid-column: span 2; }
+
+.form-label {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin-bottom: 0.5rem;
+}
+
+.form-label i { color: var(--accent-color); }
+
+.form-input,
+.form-textarea,
+.form-select {
+    width: 100%;
+    padding: 0.85rem 1rem;
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    background: var(--surface-secondary);
+    color: var(--text-primary);
+    font-size: 0.95rem;
+    transition: all 0.2s ease;
+}
+
+.form-input:focus,
+.form-textarea:focus,
+.form-select:focus {
+    outline: none;
+    border-color: var(--accent-color);
+    box-shadow: 0 0 0 3px var(--accent-light);
+}
+
+.form-textarea {
+    resize: vertical;
+    min-height: 120px;
+}
+
+.form-hint {
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    margin-top: 0.5rem;
+}
+
+.validation-message {
+    display: block;
+    font-size: 0.8rem;
+    color: var(--error-color);
+    margin-top: 0.35rem;
+}
+
+.validation-summary {
+    padding: 1rem;
+    background: rgba(239, 68, 68, 0.1);
+    border: 1px solid rgba(239, 68, 68, 0.3);
+    border-radius: 10px;
+    color: var(--error-color);
+    margin-bottom: 1.5rem;
+}
+
+.validation-summary:empty { display: none; }
+
+/* ===== ACTION BUTTONS ===== */
+.form-actions {
+    display: flex;
+    gap: 0.75rem;
+    margin-top: 1rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border-color);
+}
+
+.submit-btn,
+.btn-modern-primary {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.85rem 1.5rem;
+    background: linear-gradient(135deg, var(--accent-color) 0%, var(--accent-hover) 100%);
+    color: #ffffff;
+    border: none;
+    border-radius: 10px;
+    font-size: 0.95rem;
+    font-weight: 600;
+    cursor: pointer;
+    text-decoration: none;
+    transition: all 0.3s ease;
+}
+
+.submit-btn:hover,
+.btn-modern-primary:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 25px var(--accent-light);
+    color: #ffffff;
+}
+
+.cancel-btn,
+.btn-modern-secondary {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.85rem 1.5rem;
+    background: var(--surface-secondary);
+    color: var(--text-secondary);
+    border: 1px solid var(--border-color);
+    border-radius: 10px;
+    font-size: 0.95rem;
+    font-weight: 500;
+    text-decoration: none;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.cancel-btn:hover,
+.btn-modern-secondary:hover { color: var(--text-primary); }
+
+/* ===== RESPONSIVE ===== */
+@media (max-width: 768px) {
+    .page-container { padding: 1rem; }
+    .content-card,
+    .form-card { padding: 1.5rem; }
+    .form-row { grid-template-columns: 1fr; }
+    .form-group.full-width { grid-column: span 1; }
+    .form-actions { flex-direction: column; }
+    .submit-btn,
+    .cancel-btn,
+    .btn-modern-primary,
+    .btn-modern-secondary { justify-content: center; }
+}

--- a/src/DocFlowHub.Web/wwwroot/css/components.css
+++ b/src/DocFlowHub.Web/wwwroot/css/components.css
@@ -221,3 +221,18 @@
     .btn-modern-primary,
     .btn-modern-secondary { justify-content: center; }
 }
+
+/* ── Shared card sub-components (hoisted from per-page @section Styles) ─────────── */
+
+/* Section heading used by form-card / content-card panels */
+.section-heading { display: flex; align-items: center; gap: 0.5rem; color: var(--text-primary); font-weight: 600; margin-bottom: 1.25rem; }
+.section-heading i { color: var(--accent-color); }
+.section-heading-success i { color: var(--success-color); }
+.section-heading.text-danger,
+.section-heading.text-danger i { color: var(--error-color); }
+
+/* Parent-folder radio picker (Folders Create/Edit) */
+.parent-picker { border: 1px solid var(--border-color); border-radius: 10px; background: var(--surface-secondary); padding: 0.85rem 1rem; min-height: 120px; }
+.parent-picker .form-check { margin-bottom: 0.5rem; }
+.parent-picker .form-check-label { cursor: pointer; padding-left: 0.25rem; color: var(--text-primary); }
+.parent-picker .form-check-input:checked + .form-check-label { font-weight: 600; color: var(--accent-color); }

--- a/tests/DocFlowHub.Tests/Unit/Services/AI/AIModelHelperTests.cs
+++ b/tests/DocFlowHub.Tests/Unit/Services/AI/AIModelHelperTests.cs
@@ -101,4 +101,22 @@ public class AIModelHelperTests
             AIModelHelper.FromApiString(model.ToApiString()).Should().Be(model);
         }
     }
+
+    [Fact]
+    public void EveryModel_HasDisplayName_CostDescription_AndProvider()
+    {
+        // Guards the display/description/provider switches against a future enum value
+        // being added without extending them (the class of bug the PR review found).
+        foreach (var model in AIModelHelper.GetAllModels())
+        {
+            model.ToDisplayName().Should().NotBeNullOrWhiteSpace();
+            model.GetCostDescription().Should().NotBeNullOrWhiteSpace();
+            model.GetProvider().Should().BeOneOf(AIProvider.OpenAI, AIProvider.Anthropic);
+            // No display name should still say "GPT" for a Claude model, or vice versa.
+            if (model.GetProvider() == AIProvider.Anthropic)
+            {
+                model.ToDisplayName().Should().Contain("Claude");
+            }
+        }
+    }
 }

--- a/tests/DocFlowHub.Tests/Unit/Services/AI/AIModelHelperTests.cs
+++ b/tests/DocFlowHub.Tests/Unit/Services/AI/AIModelHelperTests.cs
@@ -1,0 +1,104 @@
+using DocFlowHub.Core.Models.AI;
+using FluentAssertions;
+using Xunit;
+
+namespace DocFlowHub.Tests.Unit.Services.AI;
+
+/// <summary>
+/// Tests for the model↔provider mapping that drives AIServiceRouter dispatch.
+/// PreferredModel is persisted as an int, so enum positions are load-bearing —
+/// these tests pin them against accidental reordering.
+/// </summary>
+public class AIModelHelperTests
+{
+    [Fact]
+    public void EnumValues_ArePinned_BecausePersistedAsInt()
+    {
+        // Existing values (DB rows depend on these ints)
+        ((int)AIModel.Gpt41).Should().Be(0);
+        ((int)AIModel.Gpt41Mini).Should().Be(1);
+        ((int)AIModel.Gpt4o).Should().Be(2);
+        ((int)AIModel.Gpt4oMini).Should().Be(3);
+        // Appended Claude values
+        ((int)AIModel.ClaudeHaiku45).Should().Be(4);
+        ((int)AIModel.ClaudeSonnet5).Should().Be(5);
+        ((int)AIModel.ClaudeOpus48).Should().Be(6);
+    }
+
+    [Theory]
+    [InlineData(AIModel.ClaudeHaiku45, "claude-haiku-4-5")]
+    [InlineData(AIModel.ClaudeSonnet5, "claude-sonnet-5")]
+    [InlineData(AIModel.ClaudeOpus48, "claude-opus-4-8")]
+    [InlineData(AIModel.Gpt4oMini, "gpt-4o-mini")]
+    public void ToApiString_MapsToProviderModelIds(AIModel model, string expected)
+    {
+        model.ToApiString().Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("claude-haiku-4-5", AIModel.ClaudeHaiku45)]
+    [InlineData("CLAUDE-OPUS-4-8", AIModel.ClaudeOpus48)]
+    [InlineData("gpt-4o-mini", AIModel.Gpt4oMini)]
+    [InlineData("gpt-4-turbo", AIModel.Gpt4o)] // legacy mapping preserved
+    public void FromApiString_RoundTripsKnownModels(string apiString, AIModel expected)
+    {
+        AIModelHelper.FromApiString(apiString).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("some-unknown-model")]
+    public void FromApiString_UnknownFallsBackToDefault(string? apiString)
+    {
+        AIModelHelper.FromApiString(apiString).Should().Be(AIModelHelper.GetDefaultModel());
+    }
+
+    [Fact]
+    public void DefaultModel_IsClaudeHaiku45()
+    {
+        AIModelHelper.GetDefaultModel().Should().Be(AIModel.ClaudeHaiku45);
+        AISettingsHelper.GetDefaultSettings("user-1").PreferredModel.Should().Be(AIModel.ClaudeHaiku45);
+    }
+
+    [Theory]
+    [InlineData(AIModel.ClaudeHaiku45, AIProvider.Anthropic)]
+    [InlineData(AIModel.ClaudeSonnet5, AIProvider.Anthropic)]
+    [InlineData(AIModel.ClaudeOpus48, AIProvider.Anthropic)]
+    [InlineData(AIModel.Gpt41, AIProvider.OpenAI)]
+    [InlineData(AIModel.Gpt4oMini, AIProvider.OpenAI)]
+    public void GetProvider_RoutesModelsToCorrectProvider(AIModel model, AIProvider expected)
+    {
+        model.GetProvider().Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("claude-haiku-4-5", AIProvider.Anthropic)]
+    [InlineData("Claude-Sonnet-5", AIProvider.Anthropic)]   // case-insensitive
+    [InlineData("gpt-4o-mini", AIProvider.OpenAI)]
+    [InlineData("anything-else", AIProvider.OpenAI)]
+    public void GetProviderForApiString_RoutesByPrefix(string apiString, AIProvider expected)
+    {
+        AIModelHelper.GetProviderForApiString(apiString).Should().Be(expected);
+    }
+
+    [Fact]
+    public void GetProviderForApiString_NullUsesDefaultModelProvider()
+    {
+        // null model → the default model's provider (Haiku → Anthropic)
+        AIModelHelper.GetProviderForApiString(null).Should().Be(AIProvider.Anthropic);
+    }
+
+    [Fact]
+    public void EveryModel_HasDistinctApiString_AndRoundTrips()
+    {
+        var models = AIModelHelper.GetAllModels();
+        var apiStrings = models.Select(m => m.ToApiString()).ToList();
+
+        apiStrings.Should().OnlyHaveUniqueItems();
+        foreach (var model in models)
+        {
+            AIModelHelper.FromApiString(model.ToApiString()).Should().Be(model);
+        }
+    }
+}

--- a/tests/DocFlowHub.Tests/Unit/Services/AI/TextExtractionServiceTests.cs
+++ b/tests/DocFlowHub.Tests/Unit/Services/AI/TextExtractionServiceTests.cs
@@ -1,0 +1,139 @@
+using System.Text;
+using DocFlowHub.Core.Services.Interfaces;
+using DocFlowHub.Infrastructure.Data;
+using DocFlowHub.Infrastructure.Services.AI;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace DocFlowHub.Tests.Unit.Services.AI;
+
+/// <summary>
+/// Exercises the real text-extraction paths (Workstream C): TXT, DOCX (OpenXML) and PDF
+/// (PdfPig). Content is generated at runtime so the tests prove genuine round-trip
+/// extraction rather than asserting against a stub.
+/// </summary>
+public class TextExtractionServiceTests
+{
+    private readonly TextExtractionService _service;
+
+    public TextExtractionServiceTests()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+        var context = new ApplicationDbContext(options);
+        var storageMock = new Mock<IDocumentStorageService>();
+        var loggerMock = new Mock<ILogger<TextExtractionService>>();
+
+        _service = new TextExtractionService(storageMock.Object, context, loggerMock.Object);
+    }
+
+    [Fact]
+    public async Task ExtractTextAsync_PlainText_ReturnsContent()
+    {
+        var bytes = Encoding.UTF8.GetBytes("Hello plain text extraction.");
+
+        var result = await _service.ExtractTextAsync(bytes, "notes.txt", "text/plain");
+
+        result.Succeeded.Should().BeTrue(result.Error);
+        result.Data.Should().Contain("Hello plain text extraction.");
+    }
+
+    [Fact]
+    public async Task ExtractTextAsync_Docx_ReturnsParagraphText()
+    {
+        const string expected = "The quarterly report shows strong growth.";
+        var bytes = CreateDocx(expected);
+
+        var result = await _service.ExtractTextAsync(
+            bytes, "report.docx",
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document");
+
+        result.Succeeded.Should().BeTrue(result.Error);
+        result.Data.Should().Contain(expected);
+    }
+
+    [Fact]
+    public async Task ExtractTextAsync_Pdf_ReturnsText()
+    {
+        const string expected = "Hello PDF extraction";
+        var bytes = CreateMinimalPdf(expected);
+
+        var result = await _service.ExtractTextAsync(bytes, "doc.pdf", "application/pdf");
+
+        result.Succeeded.Should().BeTrue(result.Error);
+        result.Data.Should().Contain("Hello");
+    }
+
+    [Fact]
+    public async Task ExtractTextAsync_LegacyDoc_DegradesGracefully()
+    {
+        // Legacy binary .doc has no OSS extractor: expect a clean "no text" failure,
+        // never a crash and never garbage bytes passed through.
+        var bytes = new byte[] { 0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1, 0x00, 0x00 };
+
+        var result = await _service.ExtractTextAsync(bytes, "old.doc", "application/msword");
+
+        result.Succeeded.Should().BeFalse();
+    }
+
+    private static byte[] CreateDocx(string text)
+    {
+        using var ms = new MemoryStream();
+        using (var doc = WordprocessingDocument.Create(ms, WordprocessingDocumentType.Document))
+        {
+            var main = doc.AddMainDocumentPart();
+            main.Document = new Document(new Body(new Paragraph(new Run(new Text(text)))));
+            main.Document.Save();
+        }
+        return ms.ToArray();
+    }
+
+    /// <summary>
+    /// Writes a minimal, valid single-page PDF showing <paramref name="text"/>, with a
+    /// correctly computed xref table. Text must not contain '(', ')' or '\'.
+    /// </summary>
+    private static byte[] CreateMinimalPdf(string text)
+    {
+        var streamContent = $"BT /F1 24 Tf 72 700 Td ({text}) Tj ET";
+        var objects = new[]
+        {
+            "<< /Type /Catalog /Pages 2 0 R >>",
+            "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>",
+            $"<< /Length {streamContent.Length} >>\nstream\n{streamContent}\nendstream",
+            "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>"
+        };
+
+        var sb = new StringBuilder();
+        sb.Append("%PDF-1.4\n");
+        var offsets = new int[objects.Length];
+        for (var i = 0; i < objects.Length; i++)
+        {
+            offsets[i] = sb.Length;
+            sb.Append($"{i + 1} 0 obj\n{objects[i]}\nendobj\n");
+        }
+
+        var xrefStart = sb.Length;
+        sb.Append("xref\n");
+        sb.Append($"0 {objects.Length + 1}\n");
+        sb.Append("0000000000 65535 f \n");
+        foreach (var offset in offsets)
+        {
+            sb.Append(offset.ToString("D10")).Append(" 00000 n \n");
+        }
+        sb.Append("trailer\n");
+        sb.Append($"<< /Size {objects.Length + 1} /Root 1 0 R >>\n");
+        sb.Append("startxref\n");
+        sb.Append($"{xrefStart}\n");
+        sb.Append("%%EOF");
+
+        return Encoding.ASCII.GetBytes(sb.ToString());
+    }
+}

--- a/tests/DocFlowHub.Tests/Unit/Services/Storage/DocumentStorageServiceTests.cs
+++ b/tests/DocFlowHub.Tests/Unit/Services/Storage/DocumentStorageServiceTests.cs
@@ -123,6 +123,30 @@ public class DocumentStorageServiceTests
     }
 
     [Fact]
+    public async Task UploadDocument_WithExtensionSpoofedContent_ShouldFail()
+    {
+        // A .pdf by name but plain text by content: passes the extension whitelist but must be
+        // rejected by the magic-byte content check wired into UploadDocumentAsync.
+        var service = new DocumentStorageService(_optionsMock.Object, _loggerMock.Object);
+        const int documentId = 104;
+        const int versionNumber = 1;
+
+        var stream = new MemoryStream(Encoding.UTF8.GetBytes("I am plain text pretending to be a PDF."));
+        var file = new FormFile(stream, 0, stream.Length, "test", "spoofed.pdf")
+        {
+            Headers = new HeaderDictionary(),
+            ContentType = "application/pdf"
+        };
+
+        // Act
+        var result = await service.UploadDocumentAsync(file, documentId, versionNumber);
+
+        // Assert
+        result.Succeeded.Should().BeFalse();
+        result.Error.Should().Contain("content does not match");
+    }
+
+    [Fact]
     public async Task UploadAndDownload_ShouldReturnSameContent()
     {
         // Arrange

--- a/tests/DocFlowHub.Tests/Unit/Services/Storage/FileSignatureValidatorTests.cs
+++ b/tests/DocFlowHub.Tests/Unit/Services/Storage/FileSignatureValidatorTests.cs
@@ -1,0 +1,176 @@
+using System.Text;
+using DocFlowHub.Infrastructure.Services.Storage;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+namespace DocFlowHub.Tests.Unit.Services.Storage;
+
+/// <summary>
+/// Unit tests for <see cref="FileSignatureValidator"/> — the magic-byte content check that
+/// stops a mislabeled file (e.g. an executable renamed to .pdf) from slipping past the
+/// extension whitelist. Pure and fast: no storage, no network.
+/// </summary>
+public class FileSignatureValidatorTests
+{
+    // Known-good leading signatures for the formats the app accepts.
+    private static readonly byte[] PdfMagic = { 0x25, 0x50, 0x44, 0x46 };                          // %PDF
+    private static readonly byte[] PngMagic = { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A };
+    private static readonly byte[] JpgMagic = { 0xFF, 0xD8, 0xFF };
+    private static readonly byte[] GifMagic = { 0x47, 0x49, 0x46, 0x38 };                          // GIF8
+    private static readonly byte[] ZipMagic = { 0x50, 0x4B, 0x03, 0x04 };                          // docx (ZIP)
+    private static readonly byte[] Ole2Magic = { 0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1 }; // legacy .doc
+
+    private static IFormFile MakeFile(byte[] content, string fileName = "upload.bin")
+    {
+        var stream = new MemoryStream(content);
+        return new FormFile(stream, 0, stream.Length, "file", fileName)
+        {
+            Headers = new HeaderDictionary(),
+            ContentType = "application/octet-stream"
+        };
+    }
+
+    private static byte[] WithPadding(byte[] magic, int totalLength = 64)
+    {
+        var buffer = new byte[Math.Max(totalLength, magic.Length)];
+        Array.Copy(magic, buffer, magic.Length);
+        // Fill the remainder with a printable byte so it looks like real trailing content.
+        for (var i = magic.Length; i < buffer.Length; i++)
+        {
+            buffer[i] = (byte)'A';
+        }
+        return buffer;
+    }
+
+    [Theory]
+    [InlineData(".pdf")]
+    [InlineData(".png")]
+    [InlineData(".jpg")]
+    [InlineData(".jpeg")]
+    [InlineData(".gif")]
+    [InlineData(".docx")]
+    [InlineData(".doc")]
+    public async Task IsContentValidAsync_WithMatchingSignature_ReturnsTrue(string extension)
+    {
+        var magic = extension switch
+        {
+            ".pdf" => PdfMagic,
+            ".png" => PngMagic,
+            ".jpg" or ".jpeg" => JpgMagic,
+            ".gif" => GifMagic,
+            ".docx" => ZipMagic,
+            ".doc" => Ole2Magic,
+            _ => throw new ArgumentOutOfRangeException(nameof(extension))
+        };
+
+        var file = MakeFile(WithPadding(magic));
+
+        var result = await FileSignatureValidator.IsContentValidAsync(file, extension);
+
+        result.Should().BeTrue($"content leads with the correct {extension} signature");
+    }
+
+    [Fact]
+    public async Task IsContentValidAsync_RenamedTextAsPdf_ReturnsFalse()
+    {
+        // The core attack: a plain-text (or any non-PDF) payload with a .pdf extension.
+        var file = MakeFile(Encoding.UTF8.GetBytes("This is not really a PDF, just text."));
+
+        var result = await FileSignatureValidator.IsContentValidAsync(file, ".pdf");
+
+        result.Should().BeFalse("the bytes do not start with %PDF");
+    }
+
+    [Fact]
+    public async Task IsContentValidAsync_ExecutableRenamedAsPng_ReturnsFalse()
+    {
+        // MZ header (Windows executable) mislabeled as a .png.
+        var mz = WithPadding(new byte[] { 0x4D, 0x5A, 0x90, 0x00 });
+
+        var result = await FileSignatureValidator.IsContentValidAsync(MakeFile(mz), ".png");
+
+        result.Should().BeFalse("an MZ executable is not a PNG");
+    }
+
+    [Fact]
+    public async Task IsContentValidAsync_WrongImageSignature_ReturnsFalse()
+    {
+        // A real GIF labeled as .png — signature mismatch must be caught.
+        var result = await FileSignatureValidator.IsContentValidAsync(MakeFile(WithPadding(GifMagic)), ".png");
+
+        result.Should().BeFalse("GIF bytes are not a PNG");
+    }
+
+    [Fact]
+    public async Task IsContentValidAsync_PlainTextWithTxtExtension_ReturnsTrue()
+    {
+        var file = MakeFile(Encoding.UTF8.GetBytes("Just some readable notes.\nSecond line."), "notes.txt");
+
+        var result = await FileSignatureValidator.IsContentValidAsync(file, ".txt");
+
+        result.Should().BeTrue("readable text with no NUL bytes is valid for .txt");
+    }
+
+    [Fact]
+    public async Task IsContentValidAsync_MarkdownWithMdExtension_ReturnsTrue()
+    {
+        var file = MakeFile(Encoding.UTF8.GetBytes("# Heading\n\nSome **markdown** body."), "readme.md");
+
+        var result = await FileSignatureValidator.IsContentValidAsync(file, ".md");
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task IsContentValidAsync_BinaryContentWithTxtExtension_ReturnsFalse()
+    {
+        // Contains a NUL byte in the sampled header => not plain text.
+        var binary = new byte[] { 0x54, 0x00, 0x65, 0x78, 0x74 }; // 'T', NUL, 'e', 'x', 't'
+
+        var result = await FileSignatureValidator.IsContentValidAsync(MakeFile(binary, "x.txt"), ".txt");
+
+        result.Should().BeFalse("a NUL byte means the payload is not plain text");
+    }
+
+    [Fact]
+    public async Task IsContentValidAsync_EmptyFile_ReturnsFalse()
+    {
+        var result = await FileSignatureValidator.IsContentValidAsync(MakeFile(Array.Empty<byte>()), ".pdf");
+
+        result.Should().BeFalse("an empty file has no valid content");
+    }
+
+    [Fact]
+    public async Task IsContentValidAsync_WhitelistedExtensionWithoutKnownSignature_ReturnsTrue()
+    {
+        // The validator is not the type authority — extensions it has no signature for are
+        // deferred to the extension whitelist and pass content validation.
+        var file = MakeFile(Encoding.UTF8.GetBytes("col1,col2\n1,2"), "data.csv");
+
+        var result = await FileSignatureValidator.IsContentValidAsync(file, ".csv");
+
+        result.Should().BeTrue("no signature on record => content check defers to the whitelist");
+    }
+
+    [Fact]
+    public async Task IsContentValidAsync_ExtensionMatchIsCaseInsensitive()
+    {
+        var file = MakeFile(WithPadding(PdfMagic));
+
+        var result = await FileSignatureValidator.IsContentValidAsync(file, ".PDF");
+
+        result.Should().BeTrue("extension comparison is case-insensitive");
+    }
+
+    [Fact]
+    public async Task IsContentValidAsync_DocxAlternateZipMarker_ReturnsTrue()
+    {
+        // Empty-archive ZIP marker (PK\x05\x06) is also a legitimate docx container start.
+        var emptyZip = WithPadding(new byte[] { 0x50, 0x4B, 0x05, 0x06 });
+
+        var result = await FileSignatureValidator.IsContentValidAsync(MakeFile(emptyZip), ".docx");
+
+        result.Should().BeTrue();
+    }
+}

--- a/tests/DocFlowHub.Tests/Unit/Services/Storage/FileSignatureValidatorTests.cs
+++ b/tests/DocFlowHub.Tests/Unit/Services/Storage/FileSignatureValidatorTests.cs
@@ -122,6 +122,20 @@ public class FileSignatureValidatorTests
         result.Should().BeTrue();
     }
 
+    [Theory]
+    // UTF-16/UTF-32 text legitimately contains NUL bytes; a recognized BOM must be accepted.
+    [InlineData(new byte[] { 0xFF, 0xFE, 0x48, 0x00, 0x69, 0x00 })]             // UTF-16 LE "Hi"
+    [InlineData(new byte[] { 0xFE, 0xFF, 0x00, 0x48, 0x00, 0x69 })]             // UTF-16 BE "Hi"
+    [InlineData(new byte[] { 0xFF, 0xFE, 0x00, 0x00, 0x48, 0x00, 0x00, 0x00 })] // UTF-32 LE "H"
+    [InlineData(new byte[] { 0x00, 0x00, 0xFE, 0xFF, 0x00, 0x00, 0x00, 0x48 })] // UTF-32 BE "H"
+    [InlineData(new byte[] { 0xEF, 0xBB, 0xBF, 0x48, 0x69 })]                   // UTF-8 BOM "Hi"
+    public async Task IsContentValidAsync_UnicodeBomText_ReturnsTrue(byte[] content)
+    {
+        var result = await FileSignatureValidator.IsContentValidAsync(MakeFile(content, "notes.txt"), ".txt");
+
+        result.Should().BeTrue("a recognized Unicode BOM marks valid text even with NUL bytes");
+    }
+
     [Fact]
     public async Task IsContentValidAsync_BinaryContentWithTxtExtension_ReturnsFalse()
     {


### PR DESCRIPTION
## Summary

Systematic remediation of the gaps found in the honest code review (`.ai/honest-code-review-2026-05-09.md`), executed as workstreams A→E per `.ai/remediation-plan.md`, plus a new multi-provider AI integration. Best reviewed **commit by commit** — each workstream is one focused commit.

### Commits
| Commit | Workstream |
|---|---|
| `435e9c5` | **A — Repo hygiene & docs**: `.gitattributes` (kills LF/CRLF churn), docs corrected (.NET 8→9, 75%-vs-100% contradiction), honest status framing |
| `8e1f50a` | **B — Security**: magic-byte content sniffing (`FileSignatureValidator`) — renamed files (e.g. exe→.pdf) can no longer bypass the extension whitelist |
| `40a2e8c` | **C — AI extraction**: real PDF (PdfPig) + DOCX (OpenXml) text extraction replacing TODO stubs; retry/backoff on OpenAI calls; legacy .doc degrades gracefully |
| `e94eac7` | **D — UI modernization**: shared `components.css`; 6 CRUD forms + 3 Document pages modernized; all 11 deep admin pages theme-corrected via one `_AdminLayout` override — every page now works in light **and** dark mode |
| `38205b3` | **E — Tests**: 17 `FileSignatureValidator` cases + upload-path wiring test + extraction round-trip tests |
| `b78d35d` | docs: remediation plan checkpoint |
| `4a41c2d` | **G — Anthropic Claude provider**: official Anthropic C# SDK, `ClaudeAIService` + per-model `AIServiceRouter` (claude-* → Anthropic, else OpenAI), Claude Haiku 4.5 / Sonnet 5 / Opus 4.8 selectable in all pickers, **default = Haiku 4.5**; enum appended safely (persisted as int, positions pinned by test) |

### Verification
- ✅ Solution builds with **0 errors**
- ✅ Test suite: **69/69 passing** (was 23 at session start; +46 new tests)
- ✅ Div-balance + hardcoded-color scans on all touched pages

### Known follow-ups (deliberately not blockers)
- [ ] **Visual pass** of modernized pages in a running app (light + dark) — code-verified only
- [ ] **Set Anthropic API key** (`dotnet user-secrets set "Anthropic:ApiKey" ...`) and smoke-test a live summary — Claude path is unit-tested but not exercised against the live API
- [ ] **Revoke the old OpenAI key** (tracked from the security review; if Claude becomes the daily driver no replacement is needed)
- [ ] Flagged test-harness expansions: E1 (chat-client seam) and E2 (`WebApplicationFactory` authz tests) — documented in `.ai/remediation-plan.md`