### PR TITLE
fix: post-sprint8 review — AI provider fallback + file-signature hardening

### DIFF
--- a/src/DocFlowHub.Core/Models/AI/AIModels.cs
+++ b/src/DocFlowHub.Core/Models/AI/AIModels.cs
@@ -76,18 +76,35 @@ public static class AIModelHelper
     /// Parse a provider API model string back to the AIModel enum.
     /// Returns the application default when the string is unknown.
     /// </summary>
-    public static AIModel FromApiString(string? apiString) => apiString?.ToLowerInvariant() switch
+    public static AIModel FromApiString(string? apiString)
     {
-        "gpt-4.1" => AIModel.Gpt41,
-        "gpt-4.1-mini" => AIModel.Gpt41Mini,
-        "gpt-4o" => AIModel.Gpt4o,
-        "gpt-4o-mini" => AIModel.Gpt4oMini,
-        "gpt-4-turbo" => AIModel.Gpt4o, // Legacy mapping
-        "claude-haiku-4-5" => AIModel.ClaudeHaiku45,
-        "claude-sonnet-5" => AIModel.ClaudeSonnet5,
-        "claude-opus-4-8" => AIModel.ClaudeOpus48,
-        _ => GetDefaultModel()
-    };
+        TryFromApiString(apiString, out var model);
+        return model;
+    }
+
+    /// <summary>
+    /// Parse a provider API model string, reporting whether it was recognized.
+    /// Unlike <see cref="FromApiString"/> (which silently falls back to the default), this
+    /// lets callers distinguish "user picked an unknown/stale value" from "user picked the
+    /// default model" — so e.g. a stale dropdown value can fall back to the user's own
+    /// preference instead of the global default. <paramref name="model"/> is set to the
+    /// application default when the string is unrecognized.
+    /// </summary>
+    public static bool TryFromApiString(string? apiString, out AIModel model)
+    {
+        switch (apiString?.ToLowerInvariant())
+        {
+            case "gpt-4.1": model = AIModel.Gpt41; return true;
+            case "gpt-4.1-mini": model = AIModel.Gpt41Mini; return true;
+            case "gpt-4o": model = AIModel.Gpt4o; return true;
+            case "gpt-4o-mini": model = AIModel.Gpt4oMini; return true;
+            case "gpt-4-turbo": model = AIModel.Gpt4o; return true; // Legacy mapping
+            case "claude-haiku-4-5": model = AIModel.ClaudeHaiku45; return true;
+            case "claude-sonnet-5": model = AIModel.ClaudeSonnet5; return true;
+            case "claude-opus-4-8": model = AIModel.ClaudeOpus48; return true;
+            default: model = GetDefaultModel(); return false;
+        }
+    }
 
     /// <summary>
     /// Convert AIModel enum to user-friendly display name
@@ -131,12 +148,20 @@ public static class AIModelHelper
     /// <summary>
     /// Which provider serves this API model string (used for request routing)
     /// </summary>
-    public static AIProvider GetProviderForApiString(string? apiString) =>
-        apiString != null && apiString.StartsWith("claude", StringComparison.OrdinalIgnoreCase)
+    public static AIProvider GetProviderForApiString(string? apiString)
+    {
+        // Null OR empty/whitespace both mean "no explicit model" -> the default model's
+        // provider. (Treating "" as OpenAI here while FromApiString("") returns the Claude
+        // default routed an empty model to the wrong provider.)
+        if (string.IsNullOrWhiteSpace(apiString))
+        {
+            return GetDefaultModel().GetProvider();
+        }
+
+        return apiString.StartsWith("claude", StringComparison.OrdinalIgnoreCase)
             ? AIProvider.Anthropic
-            : apiString == null
-                ? GetDefaultModel().GetProvider()
-                : AIProvider.OpenAI;
+            : AIProvider.OpenAI;
+    }
 
     /// <summary>
     /// Get all available models for dropdowns

--- a/src/DocFlowHub.Infrastructure/Services/AI/AIServiceRouter.cs
+++ b/src/DocFlowHub.Infrastructure/Services/AI/AIServiceRouter.cs
@@ -86,18 +86,48 @@ public class AIServiceRouter : IAIService
 
     public async Task<AIResponse> GenerateCompletionAsync(string prompt, string? model = null)
     {
-        var (service, error) = Resolve(AIModelHelper.GetProviderForApiString(model));
+        var (service, error, effectiveModel) = ResolveForCompletion(model);
         return service is null
             ? Failure(model, error)
-            : await service.GenerateCompletionAsync(prompt, model);
+            : await service.GenerateCompletionAsync(prompt, effectiveModel);
     }
 
     public async Task<AIResponse> GenerateCompletionAsync(string prompt, string systemMessage, string? model = null)
     {
-        var (service, error) = Resolve(AIModelHelper.GetProviderForApiString(model));
+        var (service, error, effectiveModel) = ResolveForCompletion(model);
         return service is null
             ? Failure(model, error)
-            : await service.GenerateCompletionAsync(prompt, systemMessage, model);
+            : await service.GenerateCompletionAsync(prompt, systemMessage, effectiveModel);
+    }
+
+    /// <summary>
+    /// Resolve the provider for a completion request, with a single-provider fallback: if the
+    /// model's own provider has no key configured but the other provider does, serve the request
+    /// on that provider using its default model. This keeps default AI features working on a
+    /// deployment that only has one provider's key (e.g. OpenAI-only), instead of hard-failing
+    /// just because the global default model belongs to the unconfigured provider.
+    /// </summary>
+    private (IAIService? Service, string? Error, string? Model) ResolveForCompletion(string? model)
+    {
+        var preferred = AIModelHelper.GetProviderForApiString(model);
+        if (IsConfigured(preferred))
+        {
+            var (service, error) = Resolve(preferred);
+            return (service, error, model);
+        }
+
+        var fallback = Other(preferred);
+        if (IsConfigured(fallback))
+        {
+            _logger.LogWarning(
+                "Requested AI provider {Preferred} is not configured; falling back to {Fallback} with its default model.",
+                preferred, fallback);
+            var (service, error) = Resolve(fallback);
+            // Drop the cross-provider model string so the fallback provider uses its own default.
+            return (service, error, null);
+        }
+
+        return (null, "No AI provider is configured (set DocFlowHub:AnthropicApiKey or OpenAI:ApiKey)", model);
     }
 
     /// <summary>

--- a/src/DocFlowHub.Infrastructure/Services/AI/AIUsageTrackingService.cs
+++ b/src/DocFlowHub.Infrastructure/Services/AI/AIUsageTrackingService.cs
@@ -119,9 +119,12 @@ public class AIUsageTrackingService : IAIUsageTrackingService
             return (estimatedTokens / 1000m) * costPer1K;
         }
 
-        // Unknown model: fall back to the application's default model cost
+        // Unknown model: fall back to the application's default model cost. Use TryGetValue
+        // (not the indexer) so a future default-model change or renamed cost entry can't turn
+        // a missing key into an unhandled KeyNotFoundException on the estimate path.
         var fallback = AIModelHelper.GetDefaultModel().ToApiString();
-        return (estimatedTokens / 1000m) * ModelCosts[fallback];
+        var fallbackCost = ModelCosts.TryGetValue(fallback, out var defaultCost) ? defaultCost : 0.001m;
+        return (estimatedTokens / 1000m) * fallbackCost;
     }
 
     /// <summary>

--- a/src/DocFlowHub.Infrastructure/Services/Storage/FileSignatureValidator.cs
+++ b/src/DocFlowHub.Infrastructure/Services/Storage/FileSignatureValidator.cs
@@ -11,7 +11,7 @@ namespace DocFlowHub.Infrastructure.Services.Storage;
 /// </summary>
 public static class FileSignatureValidator
 {
-    private const int HeaderSampleSize = 16;
+    private const int HeaderSampleSize = 32;
 
     // Extensions with no reliable binary signature (plain text): accepted if the sampled
     // header contains no NUL bytes (a cheap "this is really text, not a binary" heuristic).
@@ -61,19 +61,23 @@ public static class FileSignatureValidator
 
         if (TextExtensions.Contains(extension))
         {
-            // A byte-order mark marks a valid Unicode text encoding. UTF-16/UTF-32 text
-            // legitimately contains NUL bytes, so a recognized BOM is accepted outright —
-            // this matches TextExtractionService, which reads those encodings back.
-            if (HasTextBom(header, read))
+            var bom = DetectBom(header, read);
+
+            // UTF-16/UTF-32 text legitimately contains NUL bytes, so a multi-byte BOM is a
+            // strong "this is Unicode text" signal and we accept it (TextExtractionService
+            // reads those encodings back). A UTF-8 BOM (or no BOM) does NOT license NUL bytes:
+            // plain UTF-8 text never contains 0x00, so we still scan the payload after the BOM
+            // — otherwise a binary blob prefixed with EF BB BF and named .txt would slip past.
+            if (bom == BomKind.Utf16Or32)
             {
                 return true;
             }
 
-            for (var i = 0; i < read; i++)
+            for (var i = bom == BomKind.Utf8 ? 3 : 0; i < read; i++)
             {
                 if (header[i] == 0x00)
                 {
-                    return false; // NUL byte with no BOM => not plain text
+                    return false; // NUL byte in (BOM-stripped) UTF-8/ASCII => not plain text
                 }
             }
             return true;
@@ -84,9 +88,16 @@ public static class FileSignatureValidator
             return true; // no signature on record for this whitelisted extension
         }
 
+        // PDFs may carry a leading UTF-8 BOM or whitespace before "%PDF"; readers scan the
+        // first bytes rather than requiring offset 0. For .pdf we also try a skipped offset.
+        var pdfStart = extension.Equals(".pdf", StringComparison.OrdinalIgnoreCase)
+            ? SkipLeadingBomAndWhitespace(header, read)
+            : 0;
+
         foreach (var signature in candidates)
         {
-            if (read >= signature.Length && header.AsSpan(0, signature.Length).SequenceEqual(signature))
+            if (MatchesAt(header, read, signature, 0) ||
+                (pdfStart > 0 && MatchesAt(header, read, signature, pdfStart)))
             {
                 return true;
             }
@@ -95,11 +106,35 @@ public static class FileSignatureValidator
         return false;
     }
 
+    private static bool MatchesAt(byte[] header, int read, byte[] signature, int offset) =>
+        read - offset >= signature.Length &&
+        header.AsSpan(offset, signature.Length).SequenceEqual(signature);
+
     /// <summary>
-    /// True if the header starts with a UTF-8, UTF-16, or UTF-32 byte-order mark.
-    /// (UTF-32 is checked before UTF-16 because the UTF-16 LE BOM is a prefix of it.)
+    /// Returns the index past a leading UTF-8 BOM and any ASCII whitespace, so a signature
+    /// that tolerates leading bytes (currently only PDF) can be matched from there.
     /// </summary>
-    private static bool HasTextBom(byte[] header, int read)
+    private static int SkipLeadingBomAndWhitespace(byte[] header, int read)
+    {
+        var i = 0;
+        if (read >= 3 && header[0] == 0xEF && header[1] == 0xBB && header[2] == 0xBF)
+        {
+            i = 3;
+        }
+        while (i < read && (header[i] == 0x20 || header[i] == 0x09 || header[i] == 0x0A || header[i] == 0x0D))
+        {
+            i++;
+        }
+        return i;
+    }
+
+    private enum BomKind { None, Utf8, Utf16Or32 }
+
+    /// <summary>
+    /// Classify a leading byte-order mark. UTF-32 is checked before UTF-16 because the
+    /// UTF-16 LE BOM (FF FE) is a prefix of the UTF-32 LE BOM (FF FE 00 00).
+    /// </summary>
+    private static BomKind DetectBom(byte[] header, int read)
     {
         bool StartsWith(params byte[] bom)
         {
@@ -111,11 +146,15 @@ public static class FileSignatureValidator
             return true;
         }
 
-        return StartsWith(0x00, 0x00, 0xFE, 0xFF) // UTF-32 BE
-            || StartsWith(0xFF, 0xFE, 0x00, 0x00) // UTF-32 LE
-            || StartsWith(0xEF, 0xBB, 0xBF)        // UTF-8
-            || StartsWith(0xFE, 0xFF)              // UTF-16 BE
-            || StartsWith(0xFF, 0xFE);             // UTF-16 LE
+        if (StartsWith(0x00, 0x00, 0xFE, 0xFF) || // UTF-32 BE
+            StartsWith(0xFF, 0xFE, 0x00, 0x00) || // UTF-32 LE
+            StartsWith(0xFE, 0xFF) ||             // UTF-16 BE
+            StartsWith(0xFF, 0xFE))               // UTF-16 LE
+        {
+            return BomKind.Utf16Or32;
+        }
+
+        return StartsWith(0xEF, 0xBB, 0xBF) ? BomKind.Utf8 : BomKind.None;
     }
 
     /// <summary>

--- a/src/DocFlowHub.Web/Pages/Documents/Details.cshtml.cs
+++ b/src/DocFlowHub.Web/Pages/Documents/Details.cshtml.cs
@@ -500,10 +500,14 @@ namespace DocFlowHub.Web.Pages.Documents
         /// </summary>
         private AIModel GetSelectedAIModel()
         {
-            // If user explicitly selected a model, use that (Claude + GPT both supported)
-            if (!string.IsNullOrEmpty(ComparisonAIModel))
+            // If user explicitly selected a recognized model, use that (Claude + GPT both
+            // supported). A non-empty but unrecognized value (e.g. a stale dropdown entry)
+            // falls back to the user's own preference — not the global default — so the
+            // comparison still honors what the user configured.
+            if (!string.IsNullOrEmpty(ComparisonAIModel)
+                && AIModelHelper.TryFromApiString(ComparisonAIModel, out var selected))
             {
-                return AIModelHelper.FromApiString(ComparisonAIModel);
+                return selected;
             }
 
             return GetUserPreferredModel();

--- a/tests/DocFlowHub.Tests/Unit/Services/AI/AIModelHelperTests.cs
+++ b/tests/DocFlowHub.Tests/Unit/Services/AI/AIModelHelperTests.cs
@@ -89,6 +89,40 @@ public class AIModelHelperTests
         AIModelHelper.GetProviderForApiString(null).Should().Be(AIProvider.Anthropic);
     }
 
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void GetProviderForApiString_EmptyMatchesFromApiString_UsesDefaultProvider(string apiString)
+    {
+        // Empty/whitespace must route like null (default model's provider), consistent with
+        // FromApiString("") returning the default model — otherwise "" would route to OpenAI
+        // while the resolved model is Claude.
+        AIModelHelper.GetProviderForApiString(apiString).Should().Be(AIProvider.Anthropic);
+        AIModelHelper.GetProviderForApiString(apiString)
+            .Should().Be(AIModelHelper.FromApiString(apiString).GetProvider());
+    }
+
+    [Theory]
+    [InlineData("claude-haiku-4-5", AIModel.ClaudeHaiku45)]
+    [InlineData("GPT-4O-MINI", AIModel.Gpt4oMini)]
+    [InlineData("gpt-4-turbo", AIModel.Gpt4o)] // legacy alias still recognized
+    public void TryFromApiString_KnownModels_ReturnsTrue(string apiString, AIModel expected)
+    {
+        AIModelHelper.TryFromApiString(apiString, out var model).Should().BeTrue();
+        model.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("gpt-3.5-turbo")]   // stale/unsupported value
+    [InlineData("some-nonsense")]
+    public void TryFromApiString_UnknownModels_ReturnsFalseAndDefault(string? apiString)
+    {
+        AIModelHelper.TryFromApiString(apiString, out var model).Should().BeFalse();
+        model.Should().Be(AIModelHelper.GetDefaultModel());
+    }
+
     [Fact]
     public void EveryModel_HasDistinctApiString_AndRoundTrips()
     {

--- a/tests/DocFlowHub.Tests/Unit/Services/Storage/FileSignatureValidatorTests.cs
+++ b/tests/DocFlowHub.Tests/Unit/Services/Storage/FileSignatureValidatorTests.cs
@@ -148,6 +148,51 @@ public class FileSignatureValidatorTests
     }
 
     [Fact]
+    public async Task IsContentValidAsync_Utf8BomPrefixedBinary_ReturnsFalse()
+    {
+        // Attack: prepend the UTF-8 BOM to a NUL-containing binary and name it .txt. UTF-8 text
+        // never contains NUL, so the BOM must not license the payload past the content check.
+        var payload = new byte[] { 0xEF, 0xBB, 0xBF, 0x4D, 0x5A, 0x00, 0x00, 0x90 }; // BOM + MZ-ish + NUL
+
+        var result = await FileSignatureValidator.IsContentValidAsync(MakeFile(payload, "evil.txt"), ".txt");
+
+        result.Should().BeFalse("a UTF-8 BOM does not permit NUL bytes — the binary must still be rejected");
+    }
+
+    [Fact]
+    public async Task IsContentValidAsync_PdfWithLeadingUtf8Bom_ReturnsTrue()
+    {
+        // Some producers emit a leading UTF-8 BOM before "%PDF"; readers still accept it.
+        var bytes = new byte[] { 0xEF, 0xBB, 0xBF }.Concat(WithPadding(PdfMagic)).ToArray();
+
+        var result = await FileSignatureValidator.IsContentValidAsync(MakeFile(bytes, "doc.pdf"), ".pdf");
+
+        result.Should().BeTrue("a PDF whose %PDF marker follows a BOM is still a valid PDF");
+    }
+
+    [Fact]
+    public async Task IsContentValidAsync_PdfWithLeadingWhitespace_ReturnsTrue()
+    {
+        // Leading whitespace/newlines before %PDF are tolerated by readers.
+        var bytes = new byte[] { 0x0D, 0x0A, 0x20 }.Concat(WithPadding(PdfMagic)).ToArray();
+
+        var result = await FileSignatureValidator.IsContentValidAsync(MakeFile(bytes, "doc.pdf"), ".pdf");
+
+        result.Should().BeTrue("a PDF whose %PDF marker follows whitespace is still a valid PDF");
+    }
+
+    [Fact]
+    public async Task IsContentValidAsync_NonPdfLeadingWhitespaceTrick_StillRejected()
+    {
+        // The leading-offset tolerance is PDF-only: a PNG signature preceded by junk is NOT a PNG.
+        var bytes = new byte[] { 0x20, 0x20 }.Concat(WithPadding(GifMagic)).ToArray();
+
+        var result = await FileSignatureValidator.IsContentValidAsync(MakeFile(bytes), ".png");
+
+        result.Should().BeFalse("only PDF tolerates a leading offset; other signatures stay strict at offset 0");
+    }
+
+    [Fact]
     public async Task IsContentValidAsync_EmptyFile_ReturnsFalse()
     {
         var result = await FileSignatureValidator.IsContentValidAsync(MakeFile(Array.Empty<byte>()), ".pdf");


### PR DESCRIPTION
## Summary
Follow-up addressing the high-effort code review of the merged sprint8 work. Two focused commits, all with tests; full suite green (88/88).

### Fixed
| # | Sev | Fix |
|---|-----|-----|
| 1 | 🔴 | **Single-provider fallback** — `AIServiceRouter` now routes to the other *configured* provider (with its default model) when the requested model's provider has no key. Default AI features keep working on an OpenAI-only (or Anthropic-only) deployment instead of hard-failing because the global default is Claude. |
| 2 | 🔴 | **File-signature BOM bypass** — a binary prefixed with a UTF-8 BOM and named `.txt`/`.md` no longer skips the NUL scan (UTF-8 text has no NUL). UTF-16/32 BOMs still pass (they legitimately contain NUL). |
| 3 | 🟡 | **Valid PDFs behind a BOM/whitespace** no longer false-rejected; leading-offset tolerance is PDF-only, other signatures stay strict at offset 0. |
| 5 | 🟡 | **Compare-versions** falls back to the user's *preferred* model (not the global default) for an unrecognized `ComparisonAIModel`, via new strict `TryFromApiString`. |
| 8 | ⚪ | **Empty-string model** now routes to the default provider (consistent with `FromApiString("")`), fixing empty → wrong provider. |
| 10 | ⚪ | **Cost estimate** fallback uses `TryGetValue`, not the indexer — a future default-model change can't throw `KeyNotFoundException`. |

### Deliberately NOT changed (by-design, flagged for the record)
- **#4 Text extraction returns empty → summary fails** for legacy `.doc` / image-only PDFs. This is intentional in the merged code (the comments say it avoids feeding placeholder garbage to the summarizer) and matches the Upload page's own hint ("legacy .doc can't be read — re-save as .docx"). Restoring placeholder summaries would be a regression, not a fix.
- **#6 'Folders' sidebar link merged into 'Projects'.** The Projects nav item deliberately owns the `/Folders/*` active state — folders live under projects now. Left as-is; happy to restore a standalone entry if you'd prefer.
- **BOM-less UTF-16 `.txt` rejected** — indistinguishable from binary without a BOM; keeping the strict NUL-reject is the safer posture. Recommend saving such files with a BOM or as UTF-8.

### Deferred (⚪ cleanup, not blocking)
- **#7 Claude cost under-reported** (input-only price × combined tokens). A correct fix needs input/output token split threaded through `AIResponse`; worth a dedicated change.
- **#8/health billable probe** — `GetHealthAsync` makes a real Claude call per probe.

## Testing
- `dotnet build` clean; `dotnet test` 88/88 pass.
- New tests: UTF-8-BOM binary bypass rejected, PDF-behind-BOM/whitespace accepted, offset tolerance doesn't leak to non-PDF sigs, `TryFromApiString` strict parse, empty-string provider routing.