### PR TITLE
fix(ai): accurate token cost accounting + cheap health probe

### DIFF
--- a/src/DocFlowHub.Core/Models/AI/AIResponse.cs
+++ b/src/DocFlowHub.Core/Models/AI/AIResponse.cs
@@ -8,6 +8,10 @@ public class AIResponse
     public string Content { get; set; } = string.Empty;
     public string Model { get; set; } = string.Empty;
     public int TokensUsed { get; set; }
+    /// <summary>Prompt/input tokens, when the provider reports them (0 otherwise).</summary>
+    public int InputTokens { get; set; }
+    /// <summary>Completion/output tokens, when the provider reports them (0 otherwise).</summary>
+    public int OutputTokens { get; set; }
     public TimeSpan ResponseTime { get; set; }
     public bool IsSuccess { get; set; }
     public string? ErrorMessage { get; set; }

--- a/src/DocFlowHub.Infrastructure/Services/AI/AIUsageTrackingService.cs
+++ b/src/DocFlowHub.Infrastructure/Services/AI/AIUsageTrackingService.cs
@@ -22,19 +22,30 @@ public class AIUsageTrackingService : IAIUsageTrackingService
     private static readonly TimeSpan StatisticsCacheExpiration = TimeSpan.FromMinutes(15);
     private static readonly TimeSpan UserLimitsCacheExpiration = TimeSpan.FromMinutes(5);
 
-    // Cost per 1K tokens for different models (in USD)
-    private static readonly Dictionary<string, decimal> ModelCosts = new()
+    /// <summary>Per-1K-token USD price, split into input (prompt) and output (completion).</summary>
+    private readonly record struct TokenPrice(decimal InputPer1K, decimal OutputPer1K);
+
+    // Cost per 1K tokens for different models (USD), input and output priced separately —
+    // output is several times pricier, so charging a single rate against combined tokens
+    // materially under-reported spend (especially for Claude).
+    private static readonly Dictionary<string, TokenPrice> ModelCosts = new()
     {
-        ["gpt-4o"] = 0.005m,
-        ["gpt-4o-mini"] = 0.000150m,
-        ["gpt-4.1"] = 0.003m,
-        ["gpt-4.1-mini"] = 0.000200m,
-        ["gpt-3.5-turbo"] = 0.001m,
-        // Anthropic Claude — input price per 1K tokens
-        ["claude-haiku-4-5"] = 0.001m,
-        ["claude-sonnet-5"] = 0.003m,
-        ["claude-opus-4-8"] = 0.005m
+        ["gpt-4o"] = new(0.005m, 0.015m),
+        ["gpt-4o-mini"] = new(0.000150m, 0.000600m),
+        ["gpt-4.1"] = new(0.003m, 0.012m),
+        ["gpt-4.1-mini"] = new(0.000200m, 0.000800m),
+        ["gpt-3.5-turbo"] = new(0.0005m, 0.0015m),
+        // Anthropic Claude — $/1M: Haiku 4.5 $1/$5, Sonnet 5 $3/$15, Opus 4.8 $5/$25.
+        ["claude-haiku-4-5"] = new(0.001m, 0.005m),
+        ["claude-sonnet-5"] = new(0.003m, 0.015m),
+        ["claude-opus-4-8"] = new(0.005m, 0.025m)
     };
+
+    // Used when a model string isn't in the table — the app default's price (Haiku).
+    private static TokenPrice DefaultPrice =>
+        ModelCosts.TryGetValue(AIModelHelper.GetDefaultModel().ToApiString(), out var p)
+            ? p
+            : new TokenPrice(0.001m, 0.005m);
 
     public AIUsageTrackingService(
         ApplicationDbContext context,
@@ -65,9 +76,11 @@ public class AIUsageTrackingService : IAIUsageTrackingService
         {
             _logger.LogDebug("Logging AI usage for user {UserId}, operation {OperationType}", userId, operationType);
 
-            var estimatedCost = CalculateEstimatedCost(
-                ParseModelString(aiResponse.Model), 
-                aiResponse.TokensUsed);
+            // Price the actual input/output split when the provider reported it; fall back to
+            // the total-token estimate for older responses that only carry a combined count.
+            var estimatedCost = (aiResponse.InputTokens > 0 || aiResponse.OutputTokens > 0)
+                ? CalculateActualCost(aiResponse.Model, aiResponse.InputTokens, aiResponse.OutputTokens)
+                : CalculateEstimatedCost(ParseModelString(aiResponse.Model), aiResponse.TokensUsed);
 
             var usageLog = new AIUsageLog
             {
@@ -113,18 +126,24 @@ public class AIUsageTrackingService : IAIUsageTrackingService
     /// </summary>
     public decimal CalculateEstimatedCost(AIModel model, int estimatedTokens)
     {
-        var modelString = model.ToApiString();
-        if (ModelCosts.TryGetValue(modelString, out var costPer1K))
-        {
-            return (estimatedTokens / 1000m) * costPer1K;
-        }
+        // TryGetValue (not the indexer) so a future default-model change can't throw KeyNotFound.
+        var price = ModelCosts.TryGetValue(model.ToApiString(), out var p) ? p : DefaultPrice;
 
-        // Unknown model: fall back to the application's default model cost. Use TryGetValue
-        // (not the indexer) so a future default-model change or renamed cost entry can't turn
-        // a missing key into an unhandled KeyNotFoundException on the estimate path.
-        var fallback = AIModelHelper.GetDefaultModel().ToApiString();
-        var fallbackCost = ModelCosts.TryGetValue(fallback, out var defaultCost) ? defaultCost : 0.001m;
-        return (estimatedTokens / 1000m) * fallbackCost;
+        // Pre-execution we only have a single token estimate, no input/output split.
+        // Assume a summarization-style ~70/30 input/output mix so the shown estimate reflects
+        // the pricier output tokens rather than pricing everything at the cheap input rate.
+        var inputTokens = estimatedTokens * 0.7m;
+        var outputTokens = estimatedTokens * 0.3m;
+        return (inputTokens / 1000m) * price.InputPer1K + (outputTokens / 1000m) * price.OutputPer1K;
+    }
+
+    /// <summary>
+    /// Actual post-execution cost from the provider-reported input/output token split.
+    /// </summary>
+    private static decimal CalculateActualCost(string modelApiString, int inputTokens, int outputTokens)
+    {
+        var price = ModelCosts.TryGetValue(modelApiString, out var p) ? p : DefaultPrice;
+        return (inputTokens / 1000m) * price.InputPer1K + (outputTokens / 1000m) * price.OutputPer1K;
     }
 
     /// <summary>

--- a/src/DocFlowHub.Infrastructure/Services/AI/ClaudeAIService.cs
+++ b/src/DocFlowHub.Infrastructure/Services/AI/ClaudeAIService.cs
@@ -47,10 +47,13 @@ public class ClaudeAIService : IAIService
         {
             _logger.LogInformation("Testing Anthropic Claude service connectivity...");
 
+            // Cap output at 1 token: this probe only needs to confirm the API answers, and
+            // GetHealthAsync can be polled by dashboards — no reason to pay for a full reply.
             var response = await CreateMessageAsync(
                 "Test connection",
                 "You are a helpful assistant. Respond with just 'OK' to test connectivity.",
-                _defaultModel);
+                _defaultModel,
+                maxTokens: 1);
 
             _logger.LogInformation("Anthropic connectivity test successful. Response: {Response}", GetText(response));
             return true;
@@ -122,17 +125,20 @@ public class ClaudeAIService : IAIService
             stopwatch.Stop();
 
             var content = GetText(response);
-            var tokensUsed = (int)(response.Usage.InputTokens + response.Usage.OutputTokens);
+            var inputTokens = (int)response.Usage.InputTokens;
+            var outputTokens = (int)response.Usage.OutputTokens;
 
             _logger.LogInformation(
-                "Claude completion generated successfully. Response length: {Length} characters, Tokens used: {Tokens}",
-                content.Length, tokensUsed);
+                "Claude completion generated successfully. Response length: {Length} characters, Tokens used: {Tokens} (in: {In}, out: {Out})",
+                content.Length, inputTokens + outputTokens, inputTokens, outputTokens);
 
             return new AIResponse
             {
                 Content = content,
                 Model = selectedModel,
-                TokensUsed = tokensUsed,
+                TokensUsed = inputTokens + outputTokens,
+                InputTokens = inputTokens,
+                OutputTokens = outputTokens,
                 ResponseTime = stopwatch.Elapsed,
                 IsSuccess = true,
                 GeneratedAt = DateTime.UtcNow
@@ -154,8 +160,10 @@ public class ClaudeAIService : IAIService
         }
     }
 
-    private async Task<Message> CreateMessageAsync(string prompt, string? systemMessage, string model)
+    private async Task<Message> CreateMessageAsync(string prompt, string? systemMessage, string model, long? maxTokens = null)
     {
+        var outputCap = maxTokens ?? _maxTokens;
+
         // Role is fully qualified to avoid collision with DocFlowHub.Infrastructure.Services.Role
         var userMessage = new MessageParam
         {
@@ -167,13 +175,13 @@ public class ClaudeAIService : IAIService
             ? new MessageCreateParams
             {
                 Model = model,
-                MaxTokens = _maxTokens,
+                MaxTokens = outputCap,
                 Messages = [userMessage]
             }
             : new MessageCreateParams
             {
                 Model = model,
-                MaxTokens = _maxTokens,
+                MaxTokens = outputCap,
                 System = systemMessage,
                 Messages = [userMessage]
             };

--- a/src/DocFlowHub.Infrastructure/Services/AI/OpenAIService.cs
+++ b/src/DocFlowHub.Infrastructure/Services/AI/OpenAIService.cs
@@ -121,15 +121,20 @@ public class OpenAIService : IAIService
             stopwatch.Stop();
             
             var content = response.Value.Content[0].Text;
-            var tokensUsed = response.Value.Usage?.TotalTokenCount ?? 0;
+            var usage = response.Value.Usage;
+            var inputTokens = usage?.InputTokenCount ?? 0;
+            var outputTokens = usage?.OutputTokenCount ?? 0;
+            var tokensUsed = usage?.TotalTokenCount ?? (inputTokens + outputTokens);
 
-            _logger.LogInformation("Completion generated successfully. Response length: {Length} characters, Tokens used: {Tokens}", content.Length, tokensUsed);
+            _logger.LogInformation("Completion generated successfully. Response length: {Length} characters, Tokens used: {Tokens} (in: {In}, out: {Out})", content.Length, tokensUsed, inputTokens, outputTokens);
 
             return new AIResponse
             {
                 Content = content,
                 Model = selectedModel,
                 TokensUsed = tokensUsed,
+                InputTokens = inputTokens,
+                OutputTokens = outputTokens,
                 ResponseTime = stopwatch.Elapsed,
                 IsSuccess = true,
                 GeneratedAt = DateTime.UtcNow
@@ -175,15 +180,20 @@ public class OpenAIService : IAIService
             stopwatch.Stop();
             
             var content = response.Value.Content[0].Text;
-            var tokensUsed = response.Value.Usage?.TotalTokenCount ?? 0;
+            var usage = response.Value.Usage;
+            var inputTokens = usage?.InputTokenCount ?? 0;
+            var outputTokens = usage?.OutputTokenCount ?? 0;
+            var tokensUsed = usage?.TotalTokenCount ?? (inputTokens + outputTokens);
 
-            _logger.LogInformation("Completion generated successfully. Response length: {Length} characters, Tokens used: {Tokens}", content.Length, tokensUsed);
+            _logger.LogInformation("Completion generated successfully. Response length: {Length} characters, Tokens used: {Tokens} (in: {In}, out: {Out})", content.Length, tokensUsed, inputTokens, outputTokens);
 
             return new AIResponse
             {
                 Content = content,
                 Model = selectedModel,
                 TokensUsed = tokensUsed,
+                InputTokens = inputTokens,
+                OutputTokens = outputTokens,
                 ResponseTime = stopwatch.Elapsed,
                 IsSuccess = true,
                 GeneratedAt = DateTime.UtcNow


### PR DESCRIPTION
## Summary
The two deferred findings from the post-sprint8 review. One focused commit; full suite green (88/88).

### Fixed
| # | Sev | Fix |
|---|-----|-----|
| 7 | ⚪ | **Claude cost under-reported.** Cost was `input-rate x (input+output) tokens`, but Claude output is ~5x input, so tracked spend was materially low. `AIResponse` now carries `InputTokens`/`OutputTokens` (populated by both the Claude and OpenAI services), and `ModelCosts` prices input and output separately (Haiku $1/$5, Sonnet $3/$15, Opus $5/$25 per 1M). Actual logged cost uses the real split; the pre-upload estimate assumes a ~70/30 input/output mix. |
| 8 | ⚪ | **Health probe was a full billable reply.** `ClaudeAIService` connectivity/health check now caps output at 1 token instead of 4096 — a polled admin health widget no longer spends a full completion per probe. |

### Notes
- `AIResponse.InputTokens`/`OutputTokens` default to 0; `LogUsageAsync` falls back to the total-token estimate for any response that doesn't report a split, so nothing regresses for older/partial data.
- OpenAI rates given approximate output multipliers; Claude rates are exact per the current price list. Provider is Claude by default.

## Testing
- `dotnet build` clean; `dotnet test` 88/88.
- Verified the OpenAI SDK usage split (`InputTokenCount`/`OutputTokenCount`) compiles against the pinned SDK.