### PR TITLE
feat(ui): Slate + Sky reskin (Phases 1-6 + fixes)

### DIFF
--- a/src/DocFlowHub.Web/Pages/Account/Login.cshtml
+++ b/src/DocFlowHub.Web/Pages/Account/Login.cshtml
@@ -32,26 +32,90 @@
             color: var(--text-primary);
         }
 
-        .login-main-container {
+        /* Split layout: branded panel (left) + form (right) */
+        .auth-split {
             display: flex;
             min-height: 100vh;
-            align-items: center;
-            justify-content: center;
-            padding: var(--spacing-6);
         }
 
+        .auth-brand {
+            flex: 1 1 45%;
+            /* Deep sky -> violet ties the accent (actions) and AI identities;
+               theme-independent so white text stays readable in both themes. */
+            background: linear-gradient(160deg, #0284c7 0%, #0369a1 52%, #6d28d9 135%);
+            color: #fff;
+            display: flex;
+            align-items: center;
+            padding: var(--spacing-16) var(--spacing-12);
+            position: relative;
+            overflow: hidden;
+        }
 
+        .auth-brand-content { max-width: 460px; position: relative; z-index: 1; }
 
-        .login-container {
-            background: var(--container-bg);
-            backdrop-filter: blur(20px);
-            -webkit-backdrop-filter: blur(20px);
-            border: 1px solid var(--border-light);
-            border-radius: var(--radius-2xl);
-            padding: var(--spacing-12) var(--spacing-10);
+        .auth-logo {
+            display: flex;
+            align-items: center;
+            gap: var(--spacing-3);
+            font-size: var(--font-size-2xl);
+            font-weight: var(--font-weight-bold);
+            margin-bottom: var(--spacing-10);
+        }
+
+        .auth-logo-mark {
+            width: 44px;
+            height: 44px;
+            border-radius: var(--radius-lg);
+            background: rgba(255, 255, 255, 0.18);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-weight: var(--font-weight-extrabold);
+            font-size: 22px;
+        }
+
+        .auth-brand-title {
+            font-size: var(--font-size-4xl);
+            font-weight: var(--font-weight-extrabold);
+            line-height: 1.15;
+            margin: 0 0 var(--spacing-4) 0;
+        }
+
+        .auth-brand-sub {
+            font-size: var(--font-size-lg);
+            color: rgba(255, 255, 255, 0.85);
+            margin: 0 0 var(--spacing-10) 0;
+        }
+
+        .auth-brand-features {
+            list-style: none;
+            padding: 0;
+            margin: 0;
+            display: grid;
+            gap: var(--spacing-4);
+        }
+
+        .auth-brand-features li {
+            display: flex;
+            align-items: center;
+            gap: var(--spacing-3);
+            font-size: var(--font-size-base);
+            color: rgba(255, 255, 255, 0.92);
+        }
+
+        .auth-brand-features i { font-size: 1.2rem; opacity: 0.9; }
+
+        .auth-form-side {
+            flex: 1 1 55%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: var(--spacing-12);
+        }
+
+        .auth-form-inner {
             width: 100%;
-            max-width: 420px;
-            box-shadow: var(--shadow-glass);
+            max-width: 400px;
         }
 
         .hero-title {
@@ -276,65 +340,51 @@
             transform: scale(1.1);
         }
 
-        /* Responsive Design */
-        @@media (max-width: 768px) {
-            .login-main-container {
-                flex-direction: column;
-                gap: var(--spacing-10);
-                text-align: center;
-                padding: var(--spacing-4);
-            }
-            
-            .info-section {
-                max-width: 100%;
-            }
-            
-            .hero-title {
-                font-size: var(--font-size-3xl);
-            }
-            
-            .hero-subtitle {
-                font-size: var(--font-size-lg);
-            }
-            
-            .stats-grid {
-                grid-template-columns: 1fr;
+        /* Responsive Design — collapse to form-only on narrow screens */
+        @@media (max-width: 900px) {
+            .auth-brand { display: none; }
+            .auth-form-side {
+                flex-basis: 100%;
+                padding: var(--spacing-8);
             }
         }
 
         @@media (max-width: 480px) {
-            .login-container {
-                margin: var(--spacing-5);
-                padding: var(--spacing-8) var(--spacing-6);
-            }
-            
-            .welcome-text {
-                font-size: var(--font-size-2xl);
-            }
-            
-            .hero-title {
-                font-size: var(--font-size-2xl);
-            }
-            
-            .login-main-container {
-                gap: var(--spacing-8);
-            }
+            .auth-form-side { padding: var(--spacing-6); }
+            .hero-title { font-size: var(--font-size-3xl); }
         }
     </style>
 </head>
 <body>
     <!-- Theme Toggle -->
     <button id="themeToggle" class="login-theme-toggle" aria-label="Toggle theme">
-        <span class="theme-icon theme-icon-light" style="transition: opacity 0.3s ease;">☀️</span>
-        <span class="theme-icon theme-icon-dark" style="transition: opacity 0.3s ease; position: absolute;">🌙</span>
+        <span class="theme-icon theme-icon-light" style="transition: opacity 0.3s ease;"><i class="bi bi-sun"></i></span>
+        <span class="theme-icon theme-icon-dark" style="transition: opacity 0.3s ease; position: absolute;"><i class="bi bi-moon-stars"></i></span>
     </button>
 
-    <div class="login-main-container">
-        <div class="login-container">
-            <div class="hero-title">DocFlowHub</div>
-            <div class="hero-subtitle">Welcome back! Sign in to your account</div>
+    <div class="auth-split">
+        <aside class="auth-brand">
+            <div class="auth-brand-content">
+                <div class="auth-logo">
+                    <div class="auth-logo-mark">D</div>
+                    <span>DocFlowHub</span>
+                </div>
+                <h1 class="auth-brand-title">Manage documents with AI-powered clarity.</h1>
+                <p class="auth-brand-sub">Versioning, summaries, and team collaboration — all in one place.</p>
+                <ul class="auth-brand-features">
+                    <li><i class="bi bi-layers"></i> Version history &amp; change tracking</li>
+                    <li><i class="bi bi-robot"></i> AI summaries &amp; version comparison</li>
+                    <li><i class="bi bi-people"></i> Teams, projects &amp; shared folders</li>
+                </ul>
+            </div>
+        </aside>
 
-            <form id="account" method="post">
+        <main class="auth-form-side">
+            <div class="auth-form-inner">
+                <div class="hero-title">Welcome back</div>
+                <div class="hero-subtitle">Sign in to your account</div>
+
+                <form id="account" method="post">
                 @if (!ViewData.ModelState.IsValid)
                 {
                     <div class="validation-summary" asp-validation-summary="ModelOnly" role="alert"></div>
@@ -397,7 +447,8 @@
                     </form>
                 </div>
             }
-        </div>
+            </div>
+        </main>
     </div>
 
     <!-- Scripts -->

--- a/src/DocFlowHub.Web/Pages/Account/Manage/ChangePassword.cshtml
+++ b/src/DocFlowHub.Web/Pages/Account/Manage/ChangePassword.cshtml
@@ -236,7 +236,7 @@
     .form-input:focus {
         outline: none;
         border-color: var(--accent-color);
-        box-shadow: 0 0 0 3px rgba(5, 150, 105, 0.1);
+        box-shadow: 0 0 0 3px rgba(2, 132, 199, 0.1);
     }
     
     .toggle-password {
@@ -292,7 +292,7 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.85rem 1.5rem;
-        background: linear-gradient(135deg, var(--accent-color) 0%, rgba(5, 150, 105, 0.8) 100%);
+        background: linear-gradient(135deg, var(--accent-color) 0%, rgba(2, 132, 199, 0.8) 100%);
         color: white;
         border: none;
         border-radius: 10px;
@@ -304,7 +304,7 @@
     
     .submit-btn:hover {
         transform: translateY(-2px);
-        box-shadow: 0 8px 25px rgba(5, 150, 105, 0.3);
+        box-shadow: 0 8px 25px rgba(2, 132, 199, 0.3);
     }
     
     .cancel-btn {

--- a/src/DocFlowHub.Web/Pages/Account/Manage/ChangePassword.cshtml
+++ b/src/DocFlowHub.Web/Pages/Account/Manage/ChangePassword.cshtml
@@ -340,7 +340,7 @@
     }
     
     /* ===== DARK THEME ADJUSTMENTS ===== */
-    [data-theme="dark"] .form-card { background: rgba(45, 45, 45, 0.8); }
+    [data-theme="dark"] .form-card { background: var(--container-bg); }
     [data-theme="dark"] .security-notice { background: rgba(59, 130, 246, 0.15); }
 </style>
 }

--- a/src/DocFlowHub.Web/Pages/Account/Manage/EditProfile.cshtml
+++ b/src/DocFlowHub.Web/Pages/Account/Manage/EditProfile.cshtml
@@ -257,7 +257,7 @@
     }
     
     /* ===== DARK THEME ADJUSTMENTS ===== */
-    [data-theme="dark"] .form-card { background: rgba(45, 45, 45, 0.8); }
+    [data-theme="dark"] .form-card { background: var(--container-bg); }
 </style>
 }
 

--- a/src/DocFlowHub.Web/Pages/Account/Manage/EditProfile.cshtml
+++ b/src/DocFlowHub.Web/Pages/Account/Manage/EditProfile.cshtml
@@ -175,7 +175,7 @@
     .form-textarea:focus {
         outline: none;
         border-color: var(--accent-color);
-        box-shadow: 0 0 0 3px rgba(5, 150, 105, 0.1);
+        box-shadow: 0 0 0 3px rgba(2, 132, 199, 0.1);
     }
     
     .form-textarea {
@@ -209,7 +209,7 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.85rem 1.5rem;
-        background: linear-gradient(135deg, var(--accent-color) 0%, rgba(5, 150, 105, 0.8) 100%);
+        background: linear-gradient(135deg, var(--accent-color) 0%, rgba(2, 132, 199, 0.8) 100%);
         color: white;
         border: none;
         border-radius: 10px;
@@ -221,7 +221,7 @@
     
     .submit-btn:hover {
         transform: translateY(-2px);
-        box-shadow: 0 8px 25px rgba(5, 150, 105, 0.3);
+        box-shadow: 0 8px 25px rgba(2, 132, 199, 0.3);
     }
     
     .cancel-btn {

--- a/src/DocFlowHub.Web/Pages/Account/Manage/Index.cshtml
+++ b/src/DocFlowHub.Web/Pages/Account/Manage/Index.cshtml
@@ -254,7 +254,7 @@
     }
     
     .action-btn-primary:hover {
-        background: rgba(5, 150, 105, 0.9);
+        background: rgba(2, 132, 199, 0.9);
         color: white;
     }
     

--- a/src/DocFlowHub.Web/Pages/Account/Manage/Index.cshtml
+++ b/src/DocFlowHub.Web/Pages/Account/Manage/Index.cshtml
@@ -280,7 +280,7 @@
     }
     
     /* ===== DARK THEME ADJUSTMENTS ===== */
-    [data-theme="dark"] .profile-card { background: rgba(45, 45, 45, 0.8); }
+    [data-theme="dark"] .profile-card { background: var(--container-bg); }
 </style>
 }
 

--- a/src/DocFlowHub.Web/Pages/Account/Manage/UploadProfilePicture.cshtml
+++ b/src/DocFlowHub.Web/Pages/Account/Manage/UploadProfilePicture.cshtml
@@ -253,7 +253,7 @@
     .upload-dropzone:hover,
     .upload-dropzone.dragover {
         border-color: var(--accent-color);
-        background: rgba(5, 150, 105, 0.05);
+        background: rgba(2, 132, 199, 0.05);
     }
     
     .dropzone-icon {
@@ -264,7 +264,7 @@
         align-items: center;
         justify-content: center;
         margin: 0 auto 1rem;
-        background: linear-gradient(135deg, rgba(5, 150, 105, 0.2) 0%, rgba(5, 150, 105, 0.1) 100%);
+        background: linear-gradient(135deg, rgba(2, 132, 199, 0.2) 0%, rgba(2, 132, 199, 0.1) 100%);
         color: var(--accent-color);
         font-size: 1.75rem;
     }
@@ -353,7 +353,7 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.85rem 1.5rem;
-        background: linear-gradient(135deg, var(--accent-color) 0%, rgba(5, 150, 105, 0.8) 100%);
+        background: linear-gradient(135deg, var(--accent-color) 0%, rgba(2, 132, 199, 0.8) 100%);
         color: white;
         border: none;
         border-radius: 10px;
@@ -365,7 +365,7 @@
     
     .submit-btn:hover:not(:disabled) {
         transform: translateY(-2px);
-        box-shadow: 0 8px 25px rgba(5, 150, 105, 0.3);
+        box-shadow: 0 8px 25px rgba(2, 132, 199, 0.3);
     }
     
     .submit-btn:disabled {
@@ -408,7 +408,7 @@
     
     /* ===== DARK THEME ADJUSTMENTS ===== */
     [data-theme="dark"] .upload-card { background: rgba(45, 45, 45, 0.8); }
-    [data-theme="dark"] .upload-dropzone:hover { background: rgba(5, 150, 105, 0.1); }
+    [data-theme="dark"] .upload-dropzone:hover { background: rgba(2, 132, 199, 0.1); }
 </style>
 }
 

--- a/src/DocFlowHub.Web/Pages/Account/Manage/UploadProfilePicture.cshtml
+++ b/src/DocFlowHub.Web/Pages/Account/Manage/UploadProfilePicture.cshtml
@@ -407,7 +407,7 @@
     }
     
     /* ===== DARK THEME ADJUSTMENTS ===== */
-    [data-theme="dark"] .upload-card { background: rgba(45, 45, 45, 0.8); }
+    [data-theme="dark"] .upload-card { background: var(--container-bg); }
     [data-theme="dark"] .upload-dropzone:hover { background: rgba(2, 132, 199, 0.1); }
 </style>
 }

--- a/src/DocFlowHub.Web/Pages/Account/Manage/_ManageNav.cshtml
+++ b/src/DocFlowHub.Web/Pages/Account/Manage/_ManageNav.cshtml
@@ -151,10 +151,10 @@
     
     /* Dark theme */
     [data-theme="dark"] .manage-nav {
-        background: rgba(45, 45, 45, 0.8);
+        background: var(--container-bg);
     }
     
     [data-theme="dark"] .manage-nav-item:hover {
-        background: rgba(60, 60, 60, 0.5);
+        background: var(--surface-secondary);
     }
 </style>

--- a/src/DocFlowHub.Web/Pages/Account/Manage/_ManageNav.cshtml
+++ b/src/DocFlowHub.Web/Pages/Account/Manage/_ManageNav.cshtml
@@ -87,8 +87,8 @@
     }
     
     .manage-nav-item.active {
-        background: linear-gradient(135deg, rgba(5, 150, 105, 0.15) 0%, rgba(5, 150, 105, 0.1) 100%);
-        border: 1px solid rgba(5, 150, 105, 0.3);
+        background: linear-gradient(135deg, rgba(2, 132, 199, 0.15) 0%, rgba(2, 132, 199, 0.1) 100%);
+        border: 1px solid rgba(2, 132, 199, 0.3);
     }
     
     .manage-nav-item .nav-icon {

--- a/src/DocFlowHub.Web/Pages/Account/Register.cshtml
+++ b/src/DocFlowHub.Web/Pages/Account/Register.cshtml
@@ -72,26 +72,90 @@
             opacity: 1;
         }
 
-        .register-main-container {
+        /* Split layout: branded panel (left) + form (right) */
+        .auth-split {
             display: flex;
             min-height: 100vh;
-            align-items: center;
-            justify-content: center;
-            padding: var(--spacing-6);
         }
 
+        .auth-brand {
+            flex: 1 1 45%;
+            /* Deep sky -> violet ties the accent (actions) and AI identities;
+               theme-independent so white text stays readable in both themes. */
+            background: linear-gradient(160deg, #0284c7 0%, #0369a1 52%, #6d28d9 135%);
+            color: #fff;
+            display: flex;
+            align-items: center;
+            padding: var(--spacing-16) var(--spacing-12);
+            position: relative;
+            overflow: hidden;
+        }
 
+        .auth-brand-content { max-width: 460px; position: relative; z-index: 1; }
 
-        .register-container {
-            background: var(--container-bg);
-            backdrop-filter: blur(20px);
-            -webkit-backdrop-filter: blur(20px);
-            border: 1px solid var(--border-light);
-            border-radius: var(--radius-2xl);
-            padding: var(--spacing-12) var(--spacing-10);
+        .auth-logo {
+            display: flex;
+            align-items: center;
+            gap: var(--spacing-3);
+            font-size: var(--font-size-2xl);
+            font-weight: var(--font-weight-bold);
+            margin-bottom: var(--spacing-10);
+        }
+
+        .auth-logo-mark {
+            width: 44px;
+            height: 44px;
+            border-radius: var(--radius-lg);
+            background: rgba(255, 255, 255, 0.18);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-weight: var(--font-weight-extrabold);
+            font-size: 22px;
+        }
+
+        .auth-brand-title {
+            font-size: var(--font-size-4xl);
+            font-weight: var(--font-weight-extrabold);
+            line-height: 1.15;
+            margin: 0 0 var(--spacing-4) 0;
+        }
+
+        .auth-brand-sub {
+            font-size: var(--font-size-lg);
+            color: rgba(255, 255, 255, 0.85);
+            margin: 0 0 var(--spacing-10) 0;
+        }
+
+        .auth-brand-features {
+            list-style: none;
+            padding: 0;
+            margin: 0;
+            display: grid;
+            gap: var(--spacing-4);
+        }
+
+        .auth-brand-features li {
+            display: flex;
+            align-items: center;
+            gap: var(--spacing-3);
+            font-size: var(--font-size-base);
+            color: rgba(255, 255, 255, 0.92);
+        }
+
+        .auth-brand-features i { font-size: 1.2rem; opacity: 0.9; }
+
+        .auth-form-side {
+            flex: 1 1 55%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: var(--spacing-12);
+        }
+
+        .auth-form-inner {
             width: 100%;
-            max-width: 420px;
-            box-shadow: var(--shadow-glass);
+            max-width: 440px;
         }
 
         .hero-title {
@@ -243,52 +307,20 @@
             box-shadow: var(--shadow-sm);
         }
 
-        @@media (max-width: 1024px) {
-            .register-main-container {
-                flex-direction: column;
-            }
-            
-            .info-section {
-                padding: 40px 20px;
-                min-height: 40vh;
-            }
-            
-            .info-title {
-                font-size: 2.5rem;
-            }
-            
-            .stats-section {
-                grid-template-columns: repeat(4, 1fr);
-                gap: 1rem;
-            }
-            
-            .register-container {
-                padding: 40px 20px;
+        /* Responsive Design — collapse to form-only on narrow screens */
+        @@media (max-width: 900px) {
+            .auth-brand { display: none; }
+            .auth-form-side {
+                flex-basis: 100%;
+                padding: var(--spacing-8);
             }
         }
 
         @@media (max-width: 768px) {
-            .info-title {
-                font-size: 2rem;
-            }
-            
-            .info-subtitle {
-                font-size: 1.1rem;
-            }
-            
-            .register-form-container {
-                padding: 2rem;
-                border-radius: 16px;
-            }
-            
             .form-row {
                 grid-template-columns: 1fr;
             }
-            
-            .stats-section {
-                grid-template-columns: repeat(2, 1fr);
-            }
-            
+
             .register-theme-toggle {
                 top: 15px;
                 right: 15px;
@@ -298,22 +330,38 @@
         }
 
         @@media (max-width: 480px) {
-            .register-container {
-                padding: var(--spacing-6);
-            }
+            .auth-form-side { padding: var(--spacing-6); }
+            .hero-title { font-size: var(--font-size-3xl); }
         }
     </style>
 </head>
 <body>
     <button id="themeToggle" class="register-theme-toggle" aria-label="Toggle theme">
-        <span class="theme-icon theme-icon-light">☀️</span>
-        <span class="theme-icon theme-icon-dark" style="position: absolute;">🌙</span>
+        <span class="theme-icon theme-icon-light"><i class="bi bi-sun"></i></span>
+        <span class="theme-icon theme-icon-dark" style="position: absolute;"><i class="bi bi-moon-stars"></i></span>
     </button>
 
-    <div class="register-main-container">
-        <div class="register-container">
-            <div class="hero-title">DocFlowHub</div>
-            <div class="hero-subtitle">Create your account and get started today</div>
+    <div class="auth-split">
+        <aside class="auth-brand">
+            <div class="auth-brand-content">
+                <div class="auth-logo">
+                    <div class="auth-logo-mark">D</div>
+                    <span>DocFlowHub</span>
+                </div>
+                <h1 class="auth-brand-title">Join teams already working smarter.</h1>
+                <p class="auth-brand-sub">Create an account to organize, version, and understand your documents with AI.</p>
+                <ul class="auth-brand-features">
+                    <li><i class="bi bi-layers"></i> Version history &amp; change tracking</li>
+                    <li><i class="bi bi-robot"></i> AI summaries &amp; version comparison</li>
+                    <li><i class="bi bi-people"></i> Teams, projects &amp; shared folders</li>
+                </ul>
+            </div>
+        </aside>
+
+        <main class="auth-form-side">
+            <div class="auth-form-inner">
+                <div class="hero-title">Create your account</div>
+                <div class="hero-subtitle">Get started with DocFlowHub today</div>
 
                 <form id="registerForm" asp-route-returnUrl="@Model.ReturnUrl" method="post">
                     <div asp-validation-summary="ModelOnly" class="validation-summary" role="alert"></div>
@@ -370,7 +418,7 @@
                     </div>
                 }
             </div>
-        </div>
+        </main>
     </div>
 
     <script src="~/lib/jquery/dist/jquery.min.js"></script>

--- a/src/DocFlowHub.Web/Pages/Admin/Settings/Index.cshtml
+++ b/src/DocFlowHub.Web/Pages/Admin/Settings/Index.cshtml
@@ -485,10 +485,10 @@
     }
     
     /* ===== DARK THEME ADJUSTMENTS ===== */
-    [data-theme="dark"] .settings-category-card { background: rgba(45, 45, 45, 0.8); }
-    [data-theme="dark"] .category-header { background: rgba(60, 60, 60, 0.5); }
-    [data-theme="dark"] .setting-item:hover { background: rgba(60, 60, 60, 0.5); }
-    [data-theme="dark"] .settings-actions-card { background: rgba(45, 45, 45, 0.8); }
+    [data-theme="dark"] .settings-category-card { background: var(--container-bg); }
+    [data-theme="dark"] .category-header { background: var(--surface-secondary); }
+    [data-theme="dark"] .setting-item:hover { background: var(--surface-secondary); }
+    [data-theme="dark"] .settings-actions-card { background: var(--container-bg); }
 </style>
 }
 

--- a/src/DocFlowHub.Web/Pages/Admin/Settings/Index.cshtml
+++ b/src/DocFlowHub.Web/Pages/Admin/Settings/Index.cshtml
@@ -405,7 +405,7 @@
     .setting-textarea:focus {
         outline: none;
         border-color: var(--accent-color);
-        box-shadow: 0 0 0 3px rgba(5, 150, 105, 0.1);
+        box-shadow: 0 0 0 3px rgba(2, 132, 199, 0.1);
     }
     
     .setting-textarea { font-family: monospace; resize: vertical; }
@@ -438,7 +438,7 @@
         align-items: center;
         gap: 0.5rem;
         padding: 0.85rem 2rem;
-        background: linear-gradient(135deg, var(--accent-color) 0%, rgba(5, 150, 105, 0.8) 100%);
+        background: linear-gradient(135deg, var(--accent-color) 0%, rgba(2, 132, 199, 0.8) 100%);
         color: white;
         border: none;
         border-radius: 12px;
@@ -450,7 +450,7 @@
     
     .save-btn:hover {
         transform: translateY(-2px);
-        box-shadow: 0 8px 25px rgba(5, 150, 105, 0.3);
+        box-shadow: 0 8px 25px rgba(2, 132, 199, 0.3);
     }
     
     .cancel-btn {

--- a/src/DocFlowHub.Web/Pages/Documents/Details.cshtml
+++ b/src/DocFlowHub.Web/Pages/Documents/Details.cshtml
@@ -756,8 +756,10 @@
         line-height: 1.6;
     }
     .ai-summary-header {
-        /* Indigo→violet reads as "AI" in both themes without the harsh pure-blue block. */
-        background: linear-gradient(135deg, #4f46e5 0%, #7c3aed 100%);
+        /* Violet "AI" banner (Slate + Sky --ai-color family). Kept a deep, saturated
+           gradient — theme-independent — so the white text stays readable in both
+           light and dark (the --ai-color token itself is a light violet in dark mode). */
+        background: linear-gradient(135deg, #7c3aed 0%, #6d28d9 100%);
         color: #fff;
         border-bottom: none;
         padding: 0.85rem 1.1rem;

--- a/src/DocFlowHub.Web/Pages/Documents/Index.cshtml
+++ b/src/DocFlowHub.Web/Pages/Documents/Index.cshtml
@@ -262,25 +262,132 @@
         </div>
 
         <!-- Enhanced Documents Table -->
-        <div class="documents-table-card">
+        <div class="documents-table-card view-cards" id="documentsViewCard">
             <div class="table-card-header">
                 <div class="table-header-info">
                     <h3 class="table-title">
-                        <i class="bi bi-table"></i>
-                        Documents List
+                        <i class="bi bi-folder2-open"></i>
+                        Documents
                     </h3>
                     <p class="table-subtitle">Manage your document collection</p>
                 </div>
                 <div class="table-actions">
+                    <div class="view-toggle" role="group" aria-label="View mode">
+                        <button type="button" class="view-toggle-btn active" data-view="cards" title="Card view" aria-label="Card view">
+                            <i class="bi bi-grid-3x3-gap"></i>
+                        </button>
+                        <button type="button" class="view-toggle-btn" data-view="table" title="Table view" aria-label="Table view">
+                            <i class="bi bi-list-ul"></i>
+                        </button>
+                    </div>
                     <button class="table-action-btn" title="Refresh" onclick="window.location.reload()">
                         <i class="bi bi-arrow-clockwise"></i>
                     </button>
-                    <button class="table-action-btn" title="View options">
-                        <i class="bi bi-three-dots"></i>
-                    </button>
                 </div>
             </div>
-            
+
+            <!-- Card grid view (default) -->
+            <div class="documents-grid">
+                @foreach (var document in Model.Documents.Items)
+                {
+                    <div class="document-card">
+                        <div class="doc-card-top">
+                            <div class="document-icon @GetFileIconClass(document.FileType)">
+                                <i class="bi @GetFileIcon(document.FileType)"></i>
+                            </div>
+                            <div class="dropdown">
+                                <button class="action-dropdown-btn" type="button" data-bs-toggle="dropdown" aria-label="Document actions">
+                                    <i class="bi bi-three-dots-vertical"></i>
+                                </button>
+                                <ul class="dropdown-menu dropdown-menu-end modern-dropdown">
+                                    <li>
+                                        <a class="dropdown-item" asp-page="./Details" asp-route-id="@document.Id">
+                                            <i class="bi bi-eye"></i>
+                                            <span>View Details</span>
+                                        </a>
+                                    </li>
+                                    @if (document.OwnerId == User.GetUserId())
+                                    {
+                                        <li>
+                                            <a class="dropdown-item" asp-page="./Edit" asp-route-id="@document.Id">
+                                                <i class="bi bi-pencil"></i>
+                                                <span>Edit</span>
+                                            </a>
+                                        </li>
+                                        <li>
+                                            <button type="button" class="dropdown-item text-danger"
+                                                    onclick="confirmDeleteDocument(@document.Id, @Html.Raw(Json.Serialize(document.Title)), '@FormatFileSize(document.FileSize)', '@document.CreatedAt.ToString("MMM dd, yyyy")')">
+                                                <i class="bi bi-trash"></i>
+                                                <span>Delete</span>
+                                            </button>
+                                        </li>
+                                        <li>
+                                            <button type="button" class="dropdown-item" data-bs-toggle="modal" data-bs-target="#moveModal" data-document-id="@document.Id">
+                                                <i class="bi bi-arrows-angle-right"></i>
+                                                <span>Move</span>
+                                            </button>
+                                        </li>
+                                    }
+                                    <li><hr class="dropdown-divider"></li>
+                                    <li>
+                                        <form method="post" asp-page-handler="Download" asp-route-documentId="@document.Id" class="d-inline">
+                                            <button type="submit" class="dropdown-item text-success">
+                                                <i class="bi bi-download"></i>
+                                                <span>Download</span>
+                                            </button>
+                                        </form>
+                                    </li>
+                                </ul>
+                            </div>
+                        </div>
+
+                        <a asp-page="./Details" asp-route-id="@document.Id" class="doc-card-title">@document.Title</a>
+
+                        @if (!string.IsNullOrEmpty(document.Description))
+                        {
+                            <p class="doc-card-desc">@(document.Description.Length > 100 ? document.Description.Substring(0, 100) + "..." : document.Description)</p>
+                        }
+
+                        @if (document.Categories != null && document.Categories.Any())
+                        {
+                            <div class="document-categories">
+                                @foreach (var category in document.Categories.Take(2))
+                                {
+                                    <span class="category-tag">@category.Name</span>
+                                }
+                                @if (document.Categories.Count > 2)
+                                {
+                                    <span class="category-tag more">+@(document.Categories.Count - 2)</span>
+                                }
+                            </div>
+                        }
+
+                        <div class="doc-card-meta">
+                            @if (!string.IsNullOrEmpty(document.TeamName))
+                            {
+                                <span class="workspace-badge team" title="@document.TeamName">
+                                    <i class="bi bi-people"></i>
+                                    <span>@(document.TeamName.Length > 14 ? document.TeamName.Substring(0, 14) + "..." : document.TeamName)</span>
+                                </span>
+                            }
+                            else
+                            {
+                                <span class="workspace-badge private">
+                                    <i class="bi bi-lock"></i>
+                                    <span>Private</span>
+                                </span>
+                            }
+                            <span class="doc-card-size">@FormatFileSize(document.FileSize) · @document.FileType.ToUpper()</span>
+                        </div>
+
+                        <div class="doc-card-footer">
+                            <span><i class="bi bi-clock"></i> @((document.UpdatedAt ?? document.CreatedAt).ToString("MMM dd, yyyy"))</span>
+                            <span class="doc-card-owner">@document.OwnerName</span>
+                        </div>
+                    </div>
+                }
+            </div>
+
             <div class="modern-table-container">
                 <table class="modern-table">
                     <thead>
@@ -709,6 +816,35 @@
 
 @section Scripts {
     <script>
+        // Documents view toggle (Cards / Table) — presentation only, persisted per browser
+        (function () {
+            var STORAGE_KEY = 'docflowhub-docs-view';
+            var card = document.getElementById('documentsViewCard');
+            if (!card) return;
+            var buttons = card.querySelectorAll('.view-toggle-btn');
+
+            function applyView(view) {
+                var mode = view === 'table' ? 'table' : 'cards';
+                card.classList.toggle('view-cards', mode === 'cards');
+                card.classList.toggle('view-table', mode === 'table');
+                buttons.forEach(function (b) {
+                    b.classList.toggle('active', b.getAttribute('data-view') === mode);
+                });
+            }
+
+            var stored = null;
+            try { stored = localStorage.getItem(STORAGE_KEY); } catch (e) { }
+            if (stored) applyView(stored);
+
+            buttons.forEach(function (b) {
+                b.addEventListener('click', function () {
+                    var view = b.getAttribute('data-view');
+                    applyView(view);
+                    try { localStorage.setItem(STORAGE_KEY, view); } catch (e) { }
+                });
+            });
+        })();
+
         // Confirm delete document function
         function confirmDeleteDocument(documentId, title, size, createdDate) {
             document.getElementById('deleteDocumentId').value = documentId;
@@ -1854,6 +1990,128 @@
         .table-action-btn:hover {
             background: var(--surface-hover);
             color: var(--text-primary);
+        }
+
+        /* ===== View toggle (Cards / Table) ===== */
+        .view-toggle {
+            display: inline-flex;
+            background: var(--surface-secondary);
+            border: 1px solid var(--border-color);
+            border-radius: 8px;
+            padding: 2px;
+            gap: 2px;
+        }
+
+        .view-toggle-btn {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            width: 34px;
+            height: 30px;
+            border: none;
+            background: transparent;
+            color: var(--text-secondary);
+            border-radius: 6px;
+            cursor: pointer;
+            transition: var(--transition-all);
+        }
+
+        .view-toggle-btn:hover { color: var(--accent-color); }
+
+        .view-toggle-btn.active {
+            background: var(--surface-primary);
+            color: var(--accent-color);
+            box-shadow: var(--shadow-sm);
+        }
+
+        /* View switching — one view visible at a time */
+        .documents-table-card.view-cards .modern-table-container { display: none; }
+        .documents-table-card.view-table .documents-grid { display: none; }
+
+        /* ===== Card grid ===== */
+        .documents-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+            gap: 1rem;
+            padding: 1.25rem;
+        }
+
+        .document-card {
+            display: flex;
+            flex-direction: column;
+            gap: 0.7rem;
+            background: var(--surface-primary);
+            border: 1px solid var(--border-color);
+            border-radius: 14px;
+            padding: 1.1rem;
+            transition: var(--transition-all);
+        }
+
+        .document-card:hover {
+            border-color: var(--accent-color);
+            box-shadow: var(--shadow-md);
+            transform: translateY(-2px);
+        }
+
+        .doc-card-top {
+            display: flex;
+            align-items: flex-start;
+            justify-content: space-between;
+        }
+
+        .doc-card-title {
+            font-size: 1rem;
+            font-weight: 600;
+            color: var(--text-primary);
+            text-decoration: none;
+            line-height: 1.35;
+            word-break: break-word;
+        }
+
+        .doc-card-title:hover { color: var(--accent-color); }
+
+        .doc-card-desc {
+            font-size: 0.85rem;
+            color: var(--text-secondary);
+            margin: 0;
+            line-height: 1.5;
+        }
+
+        .doc-card-meta {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 0.5rem;
+            margin-top: auto;
+        }
+
+        .doc-card-size {
+            font-size: 0.75rem;
+            color: var(--text-muted);
+            white-space: nowrap;
+        }
+
+        .doc-card-footer {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 0.5rem;
+            padding-top: 0.6rem;
+            border-top: 1px solid var(--border-light);
+            font-size: 0.75rem;
+            color: var(--text-muted);
+        }
+
+        .doc-card-owner {
+            font-weight: 600;
+            color: var(--text-secondary);
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+
+        @@media (max-width: 480px) {
+            .documents-grid { grid-template-columns: 1fr; padding: 1rem; }
         }
 
         .modern-table-container {

--- a/src/DocFlowHub.Web/Pages/Documents/Index.cshtml
+++ b/src/DocFlowHub.Web/Pages/Documents/Index.cshtml
@@ -1215,40 +1215,17 @@
         }
 
         .modern-btn-primary {
-            background: linear-gradient(135deg, #10b981, #059669);
-            color: white;
-            box-shadow: 0 6px 20px rgba(16, 185, 129, 0.25);
+            background: linear-gradient(135deg, var(--accent-color), var(--accent-hover));
+            color: var(--text-inverse);
+            box-shadow: 0 6px 20px var(--accent-light);
             border: none;
         }
 
         .modern-btn-primary:hover {
             transform: translateY(-2px);
-            box-shadow: 0 8px 25px rgba(16, 185, 129, 0.35);
-            color: white;
-            background: linear-gradient(135deg, #34d399, #10b981);
-        }
-
-        /* Theme-specific overrides for primary buttons */
-        [data-theme="light"] .modern-btn-primary {
-            background: linear-gradient(135deg, #10b981, #059669);
-            color: white;
-            box-shadow: 0 6px 20px rgba(16, 185, 129, 0.3);
-        }
-
-        [data-theme="light"] .modern-btn-primary:hover {
-            background: linear-gradient(135deg, #34d399, #10b981);
-            box-shadow: 0 8px 25px rgba(16, 185, 129, 0.4);
-        }
-
-        [data-theme="dark"] .modern-btn-primary {
-            background: linear-gradient(135deg, #34d399, #10b981);
-            color: white;
-            box-shadow: 0 6px 20px rgba(52, 211, 153, 0.3);
-        }
-
-        [data-theme="dark"] .modern-btn-primary:hover {
-            background: linear-gradient(135deg, #6ee7b7, #34d399);
-            box-shadow: 0 8px 25px rgba(110, 231, 183, 0.4);
+            box-shadow: 0 8px 25px var(--accent-light);
+            color: var(--text-inverse);
+            background: linear-gradient(135deg, var(--accent-hover), var(--accent-color));
         }
 
         .modern-btn-outline {
@@ -1260,11 +1237,11 @@
         }
 
         .modern-btn-outline:hover {
-            background: rgba(16, 185, 129, 0.1);
-            color: #10b981;
-            border-color: #10b981;
+            background: rgba(2, 132, 199, 0.1);
+            color: var(--accent-color);
+            border-color: var(--accent-color);
             transform: translateY(-1px);
-            box-shadow: 0 6px 16px rgba(16, 185, 129, 0.15);
+            box-shadow: 0 6px 16px rgba(2, 132, 199, 0.15);
         }
 
         /* Theme-specific overrides for outline buttons */
@@ -1276,9 +1253,9 @@
         }
 
         [data-theme="light"] .modern-btn-outline:hover {
-            background: rgba(16, 185, 129, 0.05);
-            color: #10b981;
-            border-color: #10b981;
+            background: rgba(2, 132, 199, 0.05);
+            color: var(--accent-color);
+            border-color: var(--accent-color);
         }
 
         [data-theme="dark"] .modern-btn-outline {
@@ -1289,9 +1266,9 @@
         }
 
         [data-theme="dark"] .modern-btn-outline:hover {
-            background: rgba(52, 211, 153, 0.1);
-            color: #34d399;
-            border-color: #34d399;
+            background: rgba(2, 132, 199, 0.1);
+            color: var(--accent-hover);
+            border-color: var(--accent-hover);
         }
 
         /* Filter Actions Specific Styling */
@@ -1725,12 +1702,12 @@
 
         /* Enhanced Bulk Action Bar */
         .bulk-action-card {
-            background: linear-gradient(135deg, #10b981, #059669);
-            border: 1px solid #10b981;
+            background: linear-gradient(135deg, var(--accent-color), var(--accent-hover));
+            border: 1px solid var(--accent-color);
             border-radius: 12px;
             padding: 16px 20px;
             margin-bottom: 16px;
-            box-shadow: 0 12px 40px color-mix(in srgb, #10b981 25%, transparent);
+            box-shadow: 0 12px 40px color-mix(in srgb, var(--accent-color) 25%, transparent);
             animation: slideInDown 0.3s ease;
         }
 
@@ -1976,8 +1953,8 @@
         }
 
         .modern-checkbox:checked {
-            background: linear-gradient(135deg, #10b981, #059669);
-            border-color: #10b981;
+            background: linear-gradient(135deg, var(--accent-color), var(--accent-hover));
+            border-color: var(--accent-color);
             transform: scale(1.05);
         }
 
@@ -1993,8 +1970,8 @@
         }
 
         .modern-checkbox:indeterminate {
-            background: linear-gradient(135deg, #10b981, #059669);
-            border-color: #10b981;
+            background: linear-gradient(135deg, var(--accent-color), var(--accent-hover));
+            border-color: var(--accent-color);
         }
 
         .modern-checkbox:indeterminate::after {
@@ -2009,8 +1986,8 @@
         }
 
         .modern-checkbox:hover {
-            border-color: #10b981;
-            box-shadow: 0 0 0 3px rgba(16, 185, 129, 0.15);
+            border-color: var(--accent-color);
+            box-shadow: 0 0 0 3px rgba(2, 132, 199, 0.15);
         }
 
         /* Dark mode checkbox styling */
@@ -2020,18 +1997,18 @@
         }
 
         [data-theme="dark"] .modern-checkbox:checked {
-            background: linear-gradient(135deg, #34d399, #10b981);
-            border-color: #34d399;
+            background: linear-gradient(135deg, var(--accent-color), var(--accent-hover));
+            border-color: var(--accent-hover);
         }
 
         [data-theme="dark"] .modern-checkbox:indeterminate {
-            background: linear-gradient(135deg, #34d399, #10b981);
-            border-color: #34d399;
+            background: linear-gradient(135deg, var(--accent-color), var(--accent-hover));
+            border-color: var(--accent-hover);
         }
 
         [data-theme="dark"] .modern-checkbox:hover {
-            border-color: #34d399;
-            box-shadow: 0 0 0 3px rgba(52, 211, 153, 0.15);
+            border-color: var(--accent-hover);
+            box-shadow: 0 0 0 3px rgba(2, 132, 199, 0.15);
         }
 
         /* Table cell styling for checkboxes */

--- a/src/DocFlowHub.Web/Pages/Documents/Upload.cshtml
+++ b/src/DocFlowHub.Web/Pages/Documents/Upload.cshtml
@@ -1382,7 +1382,8 @@
         color: var(--text-primary);
     }
     .ai-features-header {
-        background: linear-gradient(135deg, #4f46e5 0%, #7c3aed 100%);
+        /* Violet "AI" banner — deep, theme-independent (matches Details AI card). */
+        background: linear-gradient(135deg, #7c3aed 0%, #6d28d9 100%);
         border-bottom: none;
         padding: 0.85rem 1.1rem;
     }

--- a/src/DocFlowHub.Web/Pages/Folders/Details.cshtml
+++ b/src/DocFlowHub.Web/Pages/Folders/Details.cshtml
@@ -973,16 +973,16 @@
     }
     
     /* ===== DARK THEME ADJUSTMENTS ===== */
-    [data-theme="dark"] .modern-breadcrumb { background: rgba(45, 45, 45, 0.8); }
-    [data-theme="dark"] .folder-header { background: rgba(45, 45, 45, 0.8); }
-    [data-theme="dark"] .folder-stat-card { background: rgba(45, 45, 45, 0.8); }
-    [data-theme="dark"] .folder-content-card { background: rgba(45, 45, 45, 0.8); }
-    [data-theme="dark"] .content-tabs-header { background: rgba(60, 60, 60, 0.5); }
-    [data-theme="dark"] .document-item { background: rgba(60, 60, 60, 0.5); }
-    [data-theme="dark"] .subfolder-card { background: rgba(60, 60, 60, 0.5); }
-    [data-theme="dark"] .modern-modal { background: rgba(45, 45, 45, 0.98); }
-    [data-theme="dark"] .folder-not-found { background: rgba(45, 45, 45, 0.8); }
-    [data-theme="dark"] .modern-dropdown { background: rgba(45, 45, 45, 0.95); }
+    [data-theme="dark"] .modern-breadcrumb { background: var(--container-bg); }
+    [data-theme="dark"] .folder-header { background: var(--container-bg); }
+    [data-theme="dark"] .folder-stat-card { background: var(--container-bg); }
+    [data-theme="dark"] .folder-content-card { background: var(--container-bg); }
+    [data-theme="dark"] .content-tabs-header { background: var(--surface-secondary); }
+    [data-theme="dark"] .document-item { background: var(--surface-secondary); }
+    [data-theme="dark"] .subfolder-card { background: var(--surface-secondary); }
+    [data-theme="dark"] .modern-modal { background: var(--container-bg-solid); }
+    [data-theme="dark"] .folder-not-found { background: var(--container-bg); }
+    [data-theme="dark"] .modern-dropdown { background: var(--container-bg-solid); }
 </style>
 }
 

--- a/src/DocFlowHub.Web/Pages/Folders/Details.cshtml
+++ b/src/DocFlowHub.Web/Pages/Folders/Details.cshtml
@@ -519,7 +519,7 @@
     
     .back-btn:hover {
         transform: translateY(-2px);
-        box-shadow: 0 8px 25px rgba(5, 150, 105, 0.3);
+        box-shadow: 0 8px 25px rgba(2, 132, 199, 0.3);
         color: white;
     }
     
@@ -594,7 +594,7 @@
     }
     
     .action-btn-primary { background: var(--accent-color); color: white; }
-    .action-btn-primary:hover { background: rgba(5, 150, 105, 0.9); color: white; }
+    .action-btn-primary:hover { background: rgba(2, 132, 199, 0.9); color: white; }
     .action-btn-secondary { background: var(--surface-secondary); color: var(--text-secondary); border: 1px solid var(--border-color); }
     .action-btn-secondary:hover { background: var(--surface-primary); color: var(--text-primary); }
     
@@ -718,7 +718,7 @@
         color: var(--text-secondary);
     }
     
-    .tab-btn.active .tab-badge { background: rgba(5, 150, 105, 0.15); color: var(--accent-color); }
+    .tab-btn.active .tab-badge { background: rgba(2, 132, 199, 0.15); color: var(--accent-color); }
     
     .content-tabs-body { padding: 1.5rem; }
     
@@ -836,7 +836,7 @@
     }
     
     .subfolder-btn.primary { background: var(--accent-color); color: white; }
-    .subfolder-btn.primary:hover { background: rgba(5, 150, 105, 0.9); color: white; }
+    .subfolder-btn.primary:hover { background: rgba(2, 132, 199, 0.9); color: white; }
     .subfolder-btn.secondary { background: var(--surface-primary); color: var(--text-secondary); border: 1px solid var(--border-color); }
     .subfolder-btn.secondary:hover { color: var(--text-primary); }
     
@@ -894,13 +894,13 @@
         font-size: 0.85rem;
         font-weight: 600;
         color: white;
-        background: linear-gradient(135deg, var(--accent-color) 0%, rgba(5, 150, 105, 0.8) 100%);
+        background: linear-gradient(135deg, var(--accent-color) 0%, rgba(2, 132, 199, 0.8) 100%);
         border-radius: 10px;
         text-decoration: none;
         transition: all 0.3s ease;
     }
     
-    .empty-action-btn:hover { transform: translateY(-2px); box-shadow: 0 6px 20px rgba(5, 150, 105, 0.25); color: white; }
+    .empty-action-btn:hover { transform: translateY(-2px); box-shadow: 0 6px 20px rgba(2, 132, 199, 0.25); color: white; }
     
     /* Modal Styles */
     .modern-modal {

--- a/src/DocFlowHub.Web/Pages/Folders/Index.cshtml
+++ b/src/DocFlowHub.Web/Pages/Folders/Index.cshtml
@@ -868,13 +868,13 @@
     }
     
     /* ===== DARK THEME ADJUSTMENTS ===== */
-    [data-theme="dark"] .modern-breadcrumb { background: rgba(45, 45, 45, 0.8); }
-    [data-theme="dark"] .folders-filter-panel { background: rgba(45, 45, 45, 0.8); }
-    [data-theme="dark"] .folders-tree-card { background: rgba(45, 45, 45, 0.8); }
-    [data-theme="dark"] .tree-search-bar { background: rgba(60, 60, 60, 0.6); }
-    [data-theme="dark"] .folder-item { background: rgba(60, 60, 60, 0.5); }
+    [data-theme="dark"] .modern-breadcrumb { background: var(--container-bg); }
+    [data-theme="dark"] .folders-filter-panel { background: var(--container-bg); }
+    [data-theme="dark"] .folders-tree-card { background: var(--container-bg); }
+    [data-theme="dark"] .tree-search-bar { background: var(--surface-secondary); }
+    [data-theme="dark"] .folder-item { background: var(--surface-secondary); }
     [data-theme="dark"] .folder-item:hover { background: rgba(70, 70, 70, 0.7); }
-    [data-theme="dark"] .modern-modal { background: rgba(45, 45, 45, 0.98); }
+    [data-theme="dark"] .modern-modal { background: var(--container-bg-solid); }
     [data-theme="dark"] .folders-empty-state { background: transparent; }
 </style>
 }

--- a/src/DocFlowHub.Web/Pages/Folders/Index.cshtml
+++ b/src/DocFlowHub.Web/Pages/Folders/Index.cshtml
@@ -322,14 +322,14 @@
     }
     
     .modern-btn-primary {
-        background: linear-gradient(135deg, var(--accent-color) 0%, rgba(5, 150, 105, 0.8) 100%);
+        background: linear-gradient(135deg, var(--accent-color) 0%, rgba(2, 132, 199, 0.8) 100%);
         color: white;
         border: none;
     }
     
     .modern-btn-primary:hover {
         transform: translateY(-2px);
-        box-shadow: 0 8px 25px rgba(5, 150, 105, 0.3);
+        box-shadow: 0 8px 25px rgba(2, 132, 199, 0.3);
         color: white;
     }
     
@@ -405,7 +405,7 @@
     .filter-select:focus {
         outline: none;
         border-color: var(--accent-color);
-        box-shadow: 0 0 0 3px rgba(5, 150, 105, 0.1);
+        box-shadow: 0 0 0 3px rgba(2, 132, 199, 0.1);
     }
     
     .filter-btn {
@@ -427,7 +427,7 @@
     }
     
     .filter-btn-primary:hover {
-        background: rgba(5, 150, 105, 0.9);
+        background: rgba(2, 132, 199, 0.9);
     }
     
     /* Folder Tree Card */
@@ -677,7 +677,7 @@
         font-size: 0.9rem;
         font-weight: 600;
         color: white;
-        background: linear-gradient(135deg, var(--accent-color) 0%, rgba(5, 150, 105, 0.8) 100%);
+        background: linear-gradient(135deg, var(--accent-color) 0%, rgba(2, 132, 199, 0.8) 100%);
         border-radius: 12px;
         text-decoration: none;
         transition: all 0.3s ease;
@@ -685,7 +685,7 @@
     
     .empty-action-btn:hover {
         transform: translateY(-2px);
-        box-shadow: 0 8px 25px rgba(5, 150, 105, 0.3);
+        box-shadow: 0 8px 25px rgba(2, 132, 199, 0.3);
         color: white;
     }
     

--- a/src/DocFlowHub.Web/Pages/Index.cshtml
+++ b/src/DocFlowHub.Web/Pages/Index.cshtml
@@ -109,7 +109,7 @@
 
         .nav-link:hover {
             color: var(--accent-color);
-            background: rgba(5, 150, 105, 0.1);
+            background: rgba(2, 132, 199, 0.1);
         }
 
         .nav-cta {
@@ -123,7 +123,7 @@
         }
 
         .nav-cta:hover {
-            background: rgba(5, 150, 105, 0.8);
+            background: rgba(2, 132, 199, 0.8);
             transform: translateY(-1px);
             box-shadow: var(--shadow-sm);
             color: white;
@@ -139,7 +139,7 @@
         .hero-section {
             padding: 120px 0 80px;
             position: relative;
-            background: linear-gradient(135deg, var(--accent-color) 0%, rgba(5, 150, 105, 0.8) 100%);
+            background: linear-gradient(135deg, var(--accent-color) 0%, rgba(2, 132, 199, 0.8) 100%);
             color: white;
             margin: 0;
         }
@@ -324,7 +324,7 @@
 
         .trust-section {
             padding: 80px 0;
-            background: linear-gradient(135deg, var(--accent-color) 0%, rgba(5, 150, 105, 0.8) 100%);
+            background: linear-gradient(135deg, var(--accent-color) 0%, rgba(2, 132, 199, 0.8) 100%);
             color: white;
             text-align: center;
         }
@@ -582,7 +582,7 @@
                     </p>
                     
                     <div class="hero-cta">
-                        <a href="/Account/Register" class="cta-button" style="background: linear-gradient(135deg, var(--accent-color) 0%, rgba(5, 150, 105, 0.8) 100%); color: white; border: none;">
+                        <a href="/Account/Register" class="cta-button" style="background: linear-gradient(135deg, var(--accent-color) 0%, rgba(2, 132, 199, 0.8) 100%); color: white; border: none;">
                             <i class="bi bi-rocket-takeoff"></i>
                             Start Free Trial
                         </a>
@@ -1032,14 +1032,14 @@ else
         }
         
         .dashboard-page-header .modern-btn-primary {
-            background: linear-gradient(135deg, var(--accent-color) 0%, rgba(5, 150, 105, 0.8) 100%);
+            background: linear-gradient(135deg, var(--accent-color) 0%, rgba(2, 132, 199, 0.8) 100%);
             color: white;
             border: none;
         }
         
         .dashboard-page-header .modern-btn-primary:hover {
             transform: translateY(-2px);
-            box-shadow: 0 8px 25px rgba(5, 150, 105, 0.3);
+            box-shadow: 0 8px 25px rgba(2, 132, 199, 0.3);
             color: white;
         }
         
@@ -1315,7 +1315,7 @@ else
         }
         
         .content-card-action:hover {
-            background: rgba(5, 150, 105, 0.1);
+            background: rgba(2, 132, 199, 0.1);
             color: var(--accent-color);
         }
         
@@ -1347,7 +1347,7 @@ else
         }
         
         .content-item:hover {
-            background: rgba(5, 150, 105, 0.05);
+            background: rgba(2, 132, 199, 0.05);
         }
         
         .content-item-icon {
@@ -1560,7 +1560,7 @@ else
             font-size: 0.85rem;
             font-weight: 600;
             color: white;
-            background: linear-gradient(135deg, var(--accent-color) 0%, rgba(5, 150, 105, 0.8) 100%);
+            background: linear-gradient(135deg, var(--accent-color) 0%, rgba(2, 132, 199, 0.8) 100%);
             border-radius: 10px;
             text-decoration: none;
             transition: all 0.3s ease;
@@ -1568,7 +1568,7 @@ else
         
         .empty-action-btn:hover {
             transform: translateY(-2px);
-            box-shadow: 0 6px 20px rgba(5, 150, 105, 0.25);
+            box-shadow: 0 6px 20px rgba(2, 132, 199, 0.25);
             color: white;
         }
         
@@ -1684,7 +1684,7 @@ else
         }
         
         [data-theme="dark"] .content-item:hover {
-            background: rgba(5, 150, 105, 0.1);
+            background: rgba(2, 132, 199, 0.1);
         }
         
         [data-theme="dark"] .member-count-badge {

--- a/src/DocFlowHub.Web/Pages/Index.cshtml
+++ b/src/DocFlowHub.Web/Pages/Index.cshtml
@@ -77,7 +77,7 @@
         }
 
         [data-theme="dark"] .landing-nav {
-            background: rgba(45, 45, 45, 0.95);
+            background: var(--container-bg-solid);
         }
 
         .nav-content {
@@ -1656,15 +1656,15 @@ else
         
         /* ===== DARK THEME ADJUSTMENTS ===== */
         [data-theme="dark"] .dashboard-stat-card {
-            background: rgba(45, 45, 45, 0.8);
+            background: var(--container-bg);
         }
         
         [data-theme="dark"] .dashboard-quick-actions {
-            background: rgba(45, 45, 45, 0.8);
+            background: var(--container-bg);
         }
         
         [data-theme="dark"] .quick-action-card {
-            background: rgba(60, 60, 60, 0.6);
+            background: var(--surface-secondary);
         }
         
         [data-theme="dark"] .quick-action-card:hover {
@@ -1680,7 +1680,7 @@ else
         }
         
         [data-theme="dark"] .dashboard-content-card {
-            background: rgba(45, 45, 45, 0.8);
+            background: var(--container-bg);
         }
         
         [data-theme="dark"] .content-item:hover {

--- a/src/DocFlowHub.Web/Pages/Projects/Details.cshtml
+++ b/src/DocFlowHub.Web/Pages/Projects/Details.cshtml
@@ -413,7 +413,7 @@
     
     .back-btn:hover {
         transform: translateY(-2px);
-        box-shadow: 0 8px 25px rgba(5, 150, 105, 0.3);
+        box-shadow: 0 8px 25px rgba(2, 132, 199, 0.3);
         color: white;
     }
     
@@ -447,7 +447,7 @@
         justify-content: center;
         font-size: 2.5rem;
         color: var(--project-color);
-        background: linear-gradient(135deg, rgba(5, 150, 105, 0.15) 0%, rgba(5, 150, 105, 0.05) 100%);
+        background: linear-gradient(135deg, rgba(2, 132, 199, 0.15) 0%, rgba(2, 132, 199, 0.05) 100%);
         flex-shrink: 0;
     }
     
@@ -536,7 +536,7 @@
     }
     
     .action-btn-primary:hover {
-        background: rgba(5, 150, 105, 0.9);
+        background: rgba(2, 132, 199, 0.9);
         color: white;
     }
     
@@ -721,7 +721,7 @@
     }
     
     .action-card-btn.primary:hover {
-        background: rgba(5, 150, 105, 0.9);
+        background: rgba(2, 132, 199, 0.9);
         transform: translateY(-2px);
         color: white;
     }

--- a/src/DocFlowHub.Web/Pages/Projects/Details.cshtml
+++ b/src/DocFlowHub.Web/Pages/Projects/Details.cshtml
@@ -945,35 +945,35 @@
     
     /* ===== DARK THEME ADJUSTMENTS ===== */
     [data-theme="dark"] .modern-breadcrumb {
-        background: rgba(45, 45, 45, 0.8);
+        background: var(--container-bg);
     }
     
     [data-theme="dark"] .project-header {
-        background: rgba(45, 45, 45, 0.8);
+        background: var(--container-bg);
     }
     
     [data-theme="dark"] .project-stat-card {
-        background: rgba(45, 45, 45, 0.8);
+        background: var(--container-bg);
     }
     
     [data-theme="dark"] .project-action-card {
-        background: rgba(45, 45, 45, 0.8);
+        background: var(--container-bg);
     }
     
     [data-theme="dark"] .modern-modal {
-        background: rgba(45, 45, 45, 0.98);
+        background: var(--container-bg-solid);
     }
     
     [data-theme="dark"] .modal-info-box {
-        background: rgba(60, 60, 60, 0.6);
+        background: var(--surface-secondary);
     }
     
     [data-theme="dark"] .project-not-found {
-        background: rgba(45, 45, 45, 0.8);
+        background: var(--container-bg);
     }
     
     [data-theme="dark"] .modern-dropdown {
-        background: rgba(45, 45, 45, 0.95);
+        background: var(--container-bg-solid);
     }
 </style>
 }

--- a/src/DocFlowHub.Web/Pages/Projects/Index.cshtml
+++ b/src/DocFlowHub.Web/Pages/Projects/Index.cshtml
@@ -408,14 +408,14 @@
     }
     
     .projects-page-header .modern-btn-primary {
-        background: linear-gradient(135deg, var(--accent-color) 0%, rgba(5, 150, 105, 0.8) 100%);
+        background: linear-gradient(135deg, var(--accent-color) 0%, rgba(2, 132, 199, 0.8) 100%);
         color: white;
         border: none;
     }
     
     .projects-page-header .modern-btn-primary:hover {
         transform: translateY(-2px);
-        box-shadow: 0 8px 25px rgba(5, 150, 105, 0.3);
+        box-shadow: 0 8px 25px rgba(2, 132, 199, 0.3);
         color: white;
     }
     
@@ -529,7 +529,7 @@
     .filter-select:focus {
         outline: none;
         border-color: var(--accent-color);
-        box-shadow: 0 0 0 3px rgba(5, 150, 105, 0.1);
+        box-shadow: 0 0 0 3px rgba(2, 132, 199, 0.1);
     }
     
     .filter-actions {
@@ -557,7 +557,7 @@
     }
     
     .filter-btn-primary:hover {
-        background: rgba(5, 150, 105, 0.9);
+        background: rgba(2, 132, 199, 0.9);
         color: white;
     }
     
@@ -687,7 +687,7 @@
         justify-content: center;
         font-size: 1.25rem;
         color: var(--project-color);
-        background: linear-gradient(135deg, rgba(5, 150, 105, 0.15) 0%, rgba(5, 150, 105, 0.05) 100%);
+        background: linear-gradient(135deg, rgba(2, 132, 199, 0.15) 0%, rgba(2, 132, 199, 0.05) 100%);
         flex-shrink: 0;
     }
     
@@ -922,7 +922,7 @@
         font-size: 0.9rem;
         font-weight: 600;
         color: white;
-        background: linear-gradient(135deg, var(--accent-color) 0%, rgba(5, 150, 105, 0.8) 100%);
+        background: linear-gradient(135deg, var(--accent-color) 0%, rgba(2, 132, 199, 0.8) 100%);
         border-radius: 12px;
         text-decoration: none;
         transition: all 0.3s ease;
@@ -930,7 +930,7 @@
     
     .empty-action-btn:hover {
         transform: translateY(-2px);
-        box-shadow: 0 8px 25px rgba(5, 150, 105, 0.3);
+        box-shadow: 0 8px 25px rgba(2, 132, 199, 0.3);
         color: white;
     }
     

--- a/src/DocFlowHub.Web/Pages/Projects/Index.cshtml
+++ b/src/DocFlowHub.Web/Pages/Projects/Index.cshtml
@@ -1052,11 +1052,11 @@
     
     /* ===== DARK THEME ADJUSTMENTS ===== */
     [data-theme="dark"] .projects-filter-panel {
-        background: rgba(45, 45, 45, 0.8);
+        background: var(--container-bg);
     }
     
     [data-theme="dark"] .project-card {
-        background: rgba(45, 45, 45, 0.8);
+        background: var(--container-bg);
     }
     
     [data-theme="dark"] .project-card:hover {
@@ -1064,11 +1064,11 @@
     }
     
     [data-theme="dark"] .stat-item {
-        background: rgba(60, 60, 60, 0.6);
+        background: var(--surface-secondary);
     }
     
     [data-theme="dark"] .project-card-link {
-        background: rgba(60, 60, 60, 0.6);
+        background: var(--surface-secondary);
     }
     
     [data-theme="dark"] .project-card-link:hover {
@@ -1076,7 +1076,7 @@
     }
     
     [data-theme="dark"] .modern-dropdown {
-        background: rgba(45, 45, 45, 0.95);
+        background: var(--container-bg-solid);
     }
     
     [data-theme="dark"] .modern-alert-success {
@@ -1088,7 +1088,7 @@
     }
     
     [data-theme="dark"] .projects-empty-state {
-        background: rgba(45, 45, 45, 0.8);
+        background: var(--container-bg);
     }
 </style>
 } 

--- a/src/DocFlowHub.Web/Pages/Settings/AI.cshtml
+++ b/src/DocFlowHub.Web/Pages/Settings/AI.cshtml
@@ -510,7 +510,7 @@
     .form-select:focus {
         outline: none;
         border-color: var(--accent-color);
-        box-shadow: 0 0 0 3px rgba(5, 150, 105, 0.1);
+        box-shadow: 0 0 0 3px rgba(2, 132, 199, 0.1);
     }
     
     .form-hint {
@@ -708,7 +708,7 @@
         justify-content: center;
         gap: 0.5rem;
         padding: 0.85rem 1.5rem;
-        background: linear-gradient(135deg, var(--accent-color) 0%, rgba(5, 150, 105, 0.8) 100%);
+        background: linear-gradient(135deg, var(--accent-color) 0%, rgba(2, 132, 199, 0.8) 100%);
         color: white;
         border: none;
         border-radius: 10px;
@@ -720,7 +720,7 @@
     
     .save-btn:hover {
         transform: translateY(-2px);
-        box-shadow: 0 8px 25px rgba(5, 150, 105, 0.3);
+        box-shadow: 0 8px 25px rgba(2, 132, 199, 0.3);
     }
     
     .reset-btn {

--- a/src/DocFlowHub.Web/Pages/Settings/AI.cshtml
+++ b/src/DocFlowHub.Web/Pages/Settings/AI.cshtml
@@ -515,7 +515,7 @@
     
     .form-hint {
         font-size: 0.8rem;
-        color: var(--text-tertiary);
+        color: var(--text-muted);
         margin: 0.35rem 0 0 0;
     }
     
@@ -608,7 +608,7 @@
         display: flex;
         justify-content: space-between;
         font-size: 0.75rem;
-        color: var(--text-tertiary);
+        color: var(--text-muted);
         margin-top: 0.35rem;
     }
     
@@ -657,7 +657,7 @@
     .status-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.5rem; }
     .status-label { font-size: 0.85rem; font-weight: 600; color: var(--text-primary); }
     .status-badge { padding: 0.2rem 0.5rem; border-radius: 6px; font-size: 0.75rem; font-weight: 600; }
-    .status-details { font-size: 0.8rem; color: var(--text-tertiary); }
+    .status-details { font-size: 0.8rem; color: var(--text-muted); }
     .models-label { font-size: 0.8rem; font-weight: 600; color: var(--text-primary); }
     .models-list { display: flex; flex-wrap: wrap; gap: 0.35rem; margin-top: 0.35rem; }
     
@@ -775,7 +775,7 @@
     
     .analytics-stat .stat-label {
         font-size: 0.8rem;
-        color: var(--text-tertiary);
+        color: var(--text-muted);
     }
     
     /* Charts */
@@ -898,14 +898,9 @@
         .control-group { max-width: none; }
     }
     
-    /* ===== DARK THEME ADJUSTMENTS ===== */
-    [data-theme="dark"] .settings-card { background: rgba(45, 45, 45, 0.8); }
-    [data-theme="dark"] .settings-card .card-header { background: rgba(60, 60, 60, 0.5); }
-    [data-theme="dark"] .current-status-box,
-    [data-theme="dark"] .cost-estimation-box,
-    [data-theme="dark"] .stat-card { background: rgba(60, 60, 60, 0.5); }
-    [data-theme="dark"] .connection-status { background: rgba(60, 60, 60, 0.5); }
-    
+    /* Dark theme: surfaces come from the Slate + Sky --surface-* tokens on the
+       base rules above (no charcoal-gray overrides needed anymore). */
+
     /* Spin Animation */
     .spin { animation: spin 1s linear infinite; }
     @@keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }

--- a/src/DocFlowHub.Web/Pages/Shared/_Layout.cshtml
+++ b/src/DocFlowHub.Web/Pages/Shared/_Layout.cshtml
@@ -124,6 +124,73 @@
             gap: 16px;
         }
 
+        /* Header search (center) */
+        .nav-center {
+            flex: 1;
+            display: flex;
+            justify-content: center;
+            max-width: 480px;
+            margin: 0 24px;
+        }
+
+        .header-search {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            width: 100%;
+            background: var(--surface-secondary);
+            border: 1px solid var(--border-color);
+            border-radius: 8px;
+            padding: 8px 12px;
+            transition: var(--transition-all);
+        }
+
+        .header-search:focus-within {
+            border-color: var(--border-focus);
+            box-shadow: 0 0 0 3px var(--accent-light);
+        }
+
+        .header-search i {
+            color: var(--text-muted);
+            font-size: 14px;
+        }
+
+        .header-search input {
+            border: none;
+            background: transparent;
+            outline: none;
+            color: var(--text-primary);
+            font-size: 14px;
+            width: 100%;
+        }
+
+        .header-search input::placeholder {
+            color: var(--text-muted);
+        }
+
+        /* Header Upload button (primary action) */
+        .header-upload-btn {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            background: var(--accent-color);
+            color: var(--text-inverse);
+            border: none;
+            border-radius: 8px;
+            padding: 8px 16px;
+            font-size: 14px;
+            font-weight: 600;
+            text-decoration: none;
+            white-space: nowrap;
+            transition: var(--transition-all);
+        }
+
+        .header-upload-btn:hover {
+            background: var(--accent-hover);
+            color: var(--text-inverse);
+            transform: translateY(-1px);
+        }
+
                  .theme-toggle {
              background: var(--surface-secondary);
              border: 1px solid var(--border-color);
@@ -269,6 +336,13 @@
             max-height: calc(100vh - 72px);
         }
 
+        /* Constrain content width on large/4K screens so it doesn't stretch */
+        .content-container {
+            max-width: 1440px;
+            margin: 0 auto;
+            width: 100%;
+        }
+
         /* Responsive */
         @@media (max-width: 1024px) {
             .sidebar {
@@ -297,7 +371,11 @@
             .nav-links {
                 display: none;
             }
-            
+
+            .nav-center {
+                display: none;
+            }
+
             .mobile-menu-toggle {
                 display: block;
             }
@@ -315,8 +393,12 @@
             .nav-right {
                 gap: 8px;
             }
-            
+
             .user-menu span:not(.user-avatar) {
+                display: none;
+            }
+
+            .header-upload-btn span {
                 display: none;
             }
         }
@@ -407,32 +489,27 @@
                 <div class="logo-icon">D</div>
                 <span>DocFlowHub</span>
             </a>
-                         <nav class="nav-links">
-                 <a class="nav-link @(ViewContext.RouteData.Values["Page"]?.ToString() == "/Index" ? "active" : "")" asp-area="" asp-page="/Index">
-                     <i class="bi bi-house"></i> Home
-                 </a>
-                 <a class="nav-link @(ViewContext.RouteData.Values["Page"]?.ToString()?.StartsWith("/Documents") == true ? "active" : "")" asp-area="" asp-page="/Documents/Index">
-                     <i class="bi bi-folder"></i> Documents
-                 </a>
-                 <a class="nav-link @(ViewContext.RouteData.Values["Page"]?.ToString()?.StartsWith("/Projects") == true ? "active" : "")" asp-area="" asp-page="/Projects/Index">
-                     <i class="bi bi-kanban"></i> Projects
-                 </a>
-                 <a class="nav-link @(ViewContext.RouteData.Values["Page"]?.ToString()?.StartsWith("/Teams") == true ? "active" : "")" asp-area="" asp-page="/Teams/Index">
-                     <i class="bi bi-people"></i> Teams
-                 </a>
-                 @if (SignInManager.IsSignedIn(User))
-                 {
-                     <a class="nav-link @(ViewContext.RouteData.Values["Page"]?.ToString()?.StartsWith("/Settings") == true ? "active" : "")" asp-area="" asp-page="/Settings/AI">
-                         <i class="bi bi-robot"></i> AI Settings
-                     </a>
-                 }
-             </nav>
         </div>
+        @if (SignInManager.IsSignedIn(User))
+        {
+            <div class="nav-center">
+                <form class="header-search" method="get" asp-area="" asp-page="/Documents/Index" role="search">
+                    <i class="bi bi-search"></i>
+                    <input type="search" name="Filter.SearchTerm" placeholder="Search documents..." aria-label="Search documents" />
+                </form>
+            </div>
+        }
         <div class="nav-right">
-                         <button class="theme-toggle" id="themeToggle" aria-label="Toggle theme">
-                 <span class="theme-icon theme-icon-light">☀️</span>
-                 <span class="theme-icon theme-icon-dark">🌙</span>
-             </button>
+            @if (SignInManager.IsSignedIn(User))
+            {
+                <a class="header-upload-btn" asp-area="" asp-page="/Documents/Upload">
+                    <i class="bi bi-cloud-upload"></i> <span>Upload</span>
+                </a>
+            }
+            <button class="theme-toggle" id="themeToggle" aria-label="Toggle theme">
+                <span class="theme-icon theme-icon-light"><i class="bi bi-sun"></i></span>
+                <span class="theme-icon theme-icon-dark"><i class="bi bi-moon-stars"></i></span>
+            </button>
             <partial name="_LoginPartial" />
         </div>
     </header>
@@ -519,7 +596,9 @@
 
          <!-- Content -->
          <main class="content">
-             @RenderBody()
+             <div class="content-container">
+                 @RenderBody()
+             </div>
          </main>
      </div>
 

--- a/src/DocFlowHub.Web/Pages/Teams/Details.cshtml
+++ b/src/DocFlowHub.Web/Pages/Teams/Details.cshtml
@@ -409,7 +409,7 @@
     }
     
     .action-btn-primary { background: var(--accent-color); color: white; }
-    .action-btn-primary:hover { background: rgba(5, 150, 105, 0.9); color: white; }
+    .action-btn-primary:hover { background: rgba(2, 132, 199, 0.9); color: white; }
     .action-btn-secondary { background: var(--surface-secondary); color: var(--text-secondary); border: 1px solid var(--border-color); }
     .action-btn-secondary:hover { color: var(--text-primary); }
     
@@ -484,7 +484,7 @@
     .member-email-input:focus {
         outline: none;
         border-color: var(--accent-color);
-        box-shadow: 0 0 0 3px rgba(5, 150, 105, 0.1);
+        box-shadow: 0 0 0 3px rgba(2, 132, 199, 0.1);
     }
     
     .add-member-btn {
@@ -503,7 +503,7 @@
         white-space: nowrap;
     }
     
-    .add-member-btn:hover { background: rgba(5, 150, 105, 0.9); }
+    .add-member-btn:hover { background: rgba(2, 132, 199, 0.9); }
     
     .form-hint {
         font-size: 0.8rem;

--- a/src/DocFlowHub.Web/Pages/Teams/Details.cshtml
+++ b/src/DocFlowHub.Web/Pages/Teams/Details.cshtml
@@ -719,13 +719,13 @@
     }
     
     /* ===== DARK THEME ADJUSTMENTS ===== */
-    [data-theme="dark"] .modern-breadcrumb { background: rgba(45, 45, 45, 0.8); }
-    [data-theme="dark"] .team-header-card { background: rgba(45, 45, 45, 0.8); }
-    [data-theme="dark"] .add-member-card { background: rgba(45, 45, 45, 0.8); }
-    [data-theme="dark"] .members-card { background: rgba(45, 45, 45, 0.8); }
-    [data-theme="dark"] .team-tips-card { background: rgba(45, 45, 45, 0.8); }
-    [data-theme="dark"] .member-item:hover { background: rgba(60, 60, 60, 0.6); }
-    [data-theme="dark"] .member-avatar { background: rgba(60, 60, 60, 0.6); }
+    [data-theme="dark"] .modern-breadcrumb { background: var(--container-bg); }
+    [data-theme="dark"] .team-header-card { background: var(--container-bg); }
+    [data-theme="dark"] .add-member-card { background: var(--container-bg); }
+    [data-theme="dark"] .members-card { background: var(--container-bg); }
+    [data-theme="dark"] .team-tips-card { background: var(--container-bg); }
+    [data-theme="dark"] .member-item:hover { background: var(--surface-secondary); }
+    [data-theme="dark"] .member-avatar { background: var(--surface-secondary); }
 </style>
 }
 

--- a/src/DocFlowHub.Web/Pages/Teams/Index.cshtml
+++ b/src/DocFlowHub.Web/Pages/Teams/Index.cshtml
@@ -642,10 +642,10 @@
     }
     
     /* ===== DARK THEME ADJUSTMENTS ===== */
-    [data-theme="dark"] .filter-card { background: rgba(45, 45, 45, 0.8); }
-    [data-theme="dark"] .team-card { background: rgba(45, 45, 45, 0.8); }
-    [data-theme="dark"] .team-card-footer { background: rgba(60, 60, 60, 0.5); }
-    [data-theme="dark"] .teams-empty-state { background: rgba(45, 45, 45, 0.8); }
+    [data-theme="dark"] .filter-card { background: var(--container-bg); }
+    [data-theme="dark"] .team-card { background: var(--container-bg); }
+    [data-theme="dark"] .team-card-footer { background: var(--surface-secondary); }
+    [data-theme="dark"] .teams-empty-state { background: var(--container-bg); }
 </style>
 }
 

--- a/src/DocFlowHub.Web/Pages/Teams/Index.cshtml
+++ b/src/DocFlowHub.Web/Pages/Teams/Index.cshtml
@@ -234,13 +234,13 @@
     }
     
     .modern-btn-primary {
-        background: linear-gradient(135deg, var(--accent-color) 0%, rgba(5, 150, 105, 0.8) 100%);
+        background: linear-gradient(135deg, var(--accent-color) 0%, rgba(2, 132, 199, 0.8) 100%);
         color: white;
     }
     
     .modern-btn-primary:hover {
         transform: translateY(-2px);
-        box-shadow: 0 8px 25px rgba(5, 150, 105, 0.3);
+        box-shadow: 0 8px 25px rgba(2, 132, 199, 0.3);
         color: white;
     }
     
@@ -330,7 +330,7 @@
     .filter-select:focus {
         outline: none;
         border-color: var(--accent-color);
-        box-shadow: 0 0 0 3px rgba(5, 150, 105, 0.1);
+        box-shadow: 0 0 0 3px rgba(2, 132, 199, 0.1);
     }
     
     .filter-buttons {
@@ -356,7 +356,7 @@
     }
     
     .filter-btn-primary { background: var(--accent-color); color: white; }
-    .filter-btn-primary:hover { background: rgba(5, 150, 105, 0.9); }
+    .filter-btn-primary:hover { background: rgba(2, 132, 199, 0.9); }
     .filter-btn-secondary {
         background: var(--surface-secondary);
         color: var(--text-secondary);
@@ -522,7 +522,7 @@
     }
     
     .team-btn.primary:hover {
-        background: rgba(5, 150, 105, 0.9);
+        background: rgba(2, 132, 199, 0.9);
         color: white;
     }
     
@@ -561,7 +561,7 @@
         font-size: 0.9rem;
         font-weight: 600;
         color: white;
-        background: linear-gradient(135deg, var(--accent-color) 0%, rgba(5, 150, 105, 0.8) 100%);
+        background: linear-gradient(135deg, var(--accent-color) 0%, rgba(2, 132, 199, 0.8) 100%);
         border-radius: 12px;
         text-decoration: none;
         transition: all 0.3s ease;
@@ -569,7 +569,7 @@
     
     .empty-action-btn:hover {
         transform: translateY(-2px);
-        box-shadow: 0 8px 25px rgba(5, 150, 105, 0.3);
+        box-shadow: 0 8px 25px rgba(2, 132, 199, 0.3);
         color: white;
     }
     

--- a/src/DocFlowHub.Web/wwwroot/css/themes.css
+++ b/src/DocFlowHub.Web/wwwroot/css/themes.css
@@ -5,40 +5,51 @@
 
 /* ===== ROOT THEME VARIABLES ===== */
 :root {
-  /* === LIGHT THEME (DEFAULT) === */
-  
+  /* === LIGHT THEME (DEFAULT) — "Slate + Sky" (wariant 1c) === */
+
   /* Background Gradients */
-  --bg-gradient-start: #f8fafc;
-  --bg-gradient-end: #e2e8f0;
+  --bg-gradient-start: #eef2f6;
+  --bg-gradient-end: #dfe7f0;
   --container-bg: rgba(255, 255, 255, 0.95);
   --container-bg-solid: #ffffff;
-  
-  /* Primary Colors */
-  --accent-color: #059669;
-  --accent-hover: #047857;
-  --accent-light: rgba(5, 150, 105, 0.1);
-  
+
+  /* Primary Colors (action / navigation) — Sky */
+  --accent-color: #0284c7;
+  --accent-hover: #0369a1;
+  --accent-light: rgba(2, 132, 199, 0.10);
+
+  /* AI Accent — Violet (anything AI: summaries, version-compare) */
+  --ai-color: #7c3aed;
+  --ai-light: rgba(124, 58, 237, 0.10);
+
   /* Text Colors */
-  --text-primary: #1e293b;
-  --text-secondary: #64748b;
-  --text-muted: #9ca3af;
+  --text-primary: #0f172a;
+  --text-secondary: #5c6b7f;
+  --text-muted: #94a3b8;
   --text-inverse: #ffffff;
-  
+
   /* Border Colors */
-  --border-color: #d1d5db;
-  --border-light: #e5e7eb;
-  --border-focus: #059669;
-  
+  --border-color: #dfe6ee;
+  --border-light: #eef2f6;
+  --border-focus: #0284c7;
+
   /* Surface Colors */
   --surface-primary: #ffffff;
-  --surface-secondary: #f8fafc;
-  --surface-tertiary: #f1f5f9;
-  
+  --surface-secondary: #f4f7fa;
+  --surface-tertiary: #eef2f6;
+
   /* Status Colors */
-  --success-color: #10b981;
-  --warning-color: #f59e0b;
-  --error-color: #ef4444;
-  --info-color: #3b82f6;
+  --success-color: #059669;
+  --warning-color: #d97706;
+  --error-color: #dc2626;
+  --info-color: #0284c7;
+
+  /* Semantic file-icon tints (used in tiles/lists; work in both themes) */
+  --file-doc: var(--accent-color);  /* .docx */
+  --file-pdf: var(--error-color);   /* .pdf  */
+  --file-md:  var(--ai-color);      /* .md   */
+  --file-txt: var(--info-color);    /* .txt  */
+  --file-xls: var(--success-color); /* .xlsx */
   
   /* Shadow System */
   --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
@@ -115,37 +126,41 @@
 /* ===== DARK THEME OVERRIDES ===== */
 [data-theme="dark"] {
   /* Background Gradients */
-  --bg-gradient-start: #1a1a1a;
-  --bg-gradient-end: #2d2d2d;
-  --container-bg: rgba(45, 45, 45, 0.8);
-  --container-bg-solid: #2d2d2d;
-  
-  /* Primary Colors */
-  --accent-color: #00ff88;
-  --accent-hover: #00cc6a;
-  --accent-light: rgba(0, 255, 136, 0.1);
-  
+  --bg-gradient-start: #0f172a;
+  --bg-gradient-end: #162032;
+  --container-bg: rgba(28, 39, 57, 0.80);
+  --container-bg-solid: #1c2739;
+
+  /* Primary Colors (action / navigation) — Sky */
+  --accent-color: #38bdf8;
+  --accent-hover: #0ea5e9;
+  --accent-light: rgba(56, 189, 248, 0.16);
+
+  /* AI Accent — Violet */
+  --ai-color: #a78bfa;
+  --ai-light: rgba(167, 139, 250, 0.16);
+
   /* Text Colors */
-  --text-primary: #ffffff;
-  --text-secondary: #a0a0a0;
-  --text-muted: #6b7280;
-  --text-inverse: #1a1a1a;
-  
+  --text-primary: #e4ecf5;
+  --text-secondary: #93a3b8;
+  --text-muted: #64748b;
+  --text-inverse: #0f172a;
+
   /* Border Colors */
-  --border-color: rgba(255, 255, 255, 0.1);
-  --border-light: rgba(255, 255, 255, 0.05);
-  --border-focus: #00ff88;
-  
+  --border-color: #31405a;
+  --border-light: #26324a;
+  --border-focus: #38bdf8;
+
   /* Surface Colors */
-  --surface-primary: #2d2d2d;
-  --surface-secondary: #1a1a1a;
-  --surface-tertiary: #171717;
-  
+  --surface-primary: #1c2739;
+  --surface-secondary: #162032;
+  --surface-tertiary: #111a2b;
+
   /* Status Colors (adjusted for dark theme) */
   --success-color: #34d399;
   --warning-color: #fbbf24;
   --error-color: #f87171;
-  --info-color: #60a5fa;
+  --info-color: #38bdf8;
   
   /* Shadow System (adjusted for dark theme) */
   --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.3);
@@ -159,27 +174,29 @@
 @media (prefers-color-scheme: dark) {
   :root:not([data-theme]) {
     /* Auto-apply dark theme if no explicit theme is set and user prefers dark */
-    --bg-gradient-start: #1a1a1a;
-    --bg-gradient-end: #2d2d2d;
-    --container-bg: rgba(45, 45, 45, 0.8);
-    --container-bg-solid: #2d2d2d;
-    --accent-color: #00ff88;
-    --accent-hover: #00cc6a;
-    --accent-light: rgba(0, 255, 136, 0.1);
-    --text-primary: #ffffff;
-    --text-secondary: #a0a0a0;
-    --text-muted: #6b7280;
-    --text-inverse: #1a1a1a;
-    --border-color: rgba(255, 255, 255, 0.1);
-    --border-light: rgba(255, 255, 255, 0.05);
-    --border-focus: #00ff88;
-    --surface-primary: #2d2d2d;
-    --surface-secondary: #1a1a1a;
-    --surface-tertiary: #171717;
+    --bg-gradient-start: #0f172a;
+    --bg-gradient-end: #162032;
+    --container-bg: rgba(28, 39, 57, 0.80);
+    --container-bg-solid: #1c2739;
+    --accent-color: #38bdf8;
+    --accent-hover: #0ea5e9;
+    --accent-light: rgba(56, 189, 248, 0.16);
+    --ai-color: #a78bfa;
+    --ai-light: rgba(167, 139, 250, 0.16);
+    --text-primary: #e4ecf5;
+    --text-secondary: #93a3b8;
+    --text-muted: #64748b;
+    --text-inverse: #0f172a;
+    --border-color: #31405a;
+    --border-light: #26324a;
+    --border-focus: #38bdf8;
+    --surface-primary: #1c2739;
+    --surface-secondary: #162032;
+    --surface-tertiary: #111a2b;
     --success-color: #34d399;
     --warning-color: #fbbf24;
     --error-color: #f87171;
-    --info-color: #60a5fa;
+    --info-color: #38bdf8;
     --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.3);
     --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.4);
     --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.5);

--- a/src/DocFlowHub.Web/wwwroot/css/themes.css
+++ b/src/DocFlowHub.Web/wwwroot/css/themes.css
@@ -26,6 +26,9 @@
   --text-primary: #0f172a;
   --text-secondary: #5c6b7f;
   --text-muted: #94a3b8;
+  /* Alias: several pages reference --text-tertiary (never defined); map it to
+     --text-muted so it resolves and auto-adapts per theme. */
+  --text-tertiary: var(--text-muted);
   --text-inverse: #ffffff;
 
   /* Border Colors */


### PR DESCRIPTION
## Slate + Sky UI refactor — full reskin

Reskins DocFlowHub to the **"Slate + Sky" (variant 1c)** design handoff. Presentation-only; no behavior changes. Every chunk built clean and was smoke-tested (authenticated layout + login flow + Documents list driven via curl).

| Chunk | What |
|---|---|
| **Phase 1** | Palette: sky accent + slate surfaces, neon-green removed, `--ai-*`/`--file-*` tokens; killed green accent stragglers across 15 pages |
| **Phase 2** | Nav unification: single top bar, working header search, sky Upload button, `bi-sun`/`bi-moon-stars` toggle, 1440px content cap |
| **Phase 4** | AI banners (Details + Upload) → deep violet |
| **Phase 5** | AI Settings dark-mode consistency |
| **Dark sweep** | 13 pages: charcoal dark surfaces → slate tokens (killed charcoal islands) |
| **Phase 6** | Split-panel Login + Register (brand panel + form) |
| **Phase 3** | Documents card grid + Cards/Table toggle (additive; table/bulk machinery untouched) |
| **Fix** | `--text-tertiary` alias → `--text-muted` (was undefined on 13 pages) |

### Verification
- `dotnet build` clean at each step.
- curl login (seeded admin + a user with documents) → authenticated `_Layout`, header search round-trips, Documents shows 9 cards == 9 table rows, login still authenticates after the auth-page redesign.
- **Not yet visually reviewed in a browser** (no browser-driving available in the dev env) — recommend a manual light/dark pass.

### Remaining (optional, separate)
- **Phase 7** — extract shared card/tile/badge styles into `components.css` (invisible cleanup; deferred until the visible result is confirmed).