### PR TITLE
fix(ui): slate dark surface for shared cards (Phase 7)

### DIFF
--- a/src/DocFlowHub.Web/wwwroot/css/components.css
+++ b/src/DocFlowHub.Web/wwwroot/css/components.css
@@ -70,10 +70,8 @@
     padding: 2rem;
 }
 
-[data-theme="dark"] .content-card,
-[data-theme="dark"] .form-card {
-    background: rgba(45, 45, 45, 0.8);
-}
+/* Dark surface comes from --surface-primary (slate) on the base rule above;
+   no charcoal-gray override needed. */
 
 .content-card.glass,
 .form-card.glass {


### PR DESCRIPTION
## Phase 7 — shared-styles pass

The earlier Slate + Sky dark-surface sweep only ran over `Pages/*.cshtml`, so one leftover survived in `wwwroot/css/components.css`: the shared `.content-card` / `.form-card` dark override still forced the old charcoal gray (`rgba(45,45,45,0.8)`) — a charcoal island in the slate dark theme on every form/content-card page. Removed it; the base rule already uses `var(--surface-primary)` (slate in dark).

### Audit outcome
- Swept all `wwwroot/css/*` — no other charcoal / neon-green leftovers.
- The genuinely-shared system (page container, cards, forms, buttons, section headings) **already lives in `components.css`**; the remaining per-page styles (Documents tiles/badges/toggle, auth split panel) are single-use, so there's no de-duplication value in hoisting them — and the auth pages use `Layout = null` and don't load `components.css` anyway. Phase 7's "extract shared styles" goal is effectively met.

Presentation-only.