### PR TITLE
feat(demo): read-only public demo mode (seed + guard + deploy)

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -1,0 +1,43 @@
+name: Deploy demo to Azure
+
+# Manual-trigger only — click "Run workflow" in the Actions tab when you want to
+# deploy the read-only demo. (No push trigger, so normal commits never deploy.)
+on:
+  workflow_dispatch:
+
+env:
+  AZURE_WEBAPP_NAME: docflowhub-demo        # <-- set to your Azure App Service name
+  DOTNET_VERSION: '9.0.x'
+  PUBLISH_DIR: ${{ github.workspace }}/publish
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Restore
+        run: dotnet restore DocFlowHub.sln
+
+      - name: Build
+        run: dotnet build DocFlowHub.sln -c Release --no-restore
+
+      - name: Publish web app
+        run: dotnet publish src/DocFlowHub.Web/DocFlowHub.Web.csproj -c Release -o "${{ env.PUBLISH_DIR }}" --no-build
+
+      - name: Deploy to Azure App Service
+        uses: azure/webapps-deploy@v3
+        with:
+          app-name: ${{ env.AZURE_WEBAPP_NAME }}
+          publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
+          package: ${{ env.PUBLISH_DIR }}
+
+# On first request after deploy, the app runs EF migrations and (because
+# DemoMode:Enabled=true) seeds the demo dataset. No AI key is configured, so
+# AI generation is disabled by design.

--- a/docs/demo-deployment.md
+++ b/docs/demo-deployment.md
@@ -1,0 +1,81 @@
+# Deploying the read-only demo to Azure (free tiers)
+
+This is the step-by-step for putting DocFlowHub online as a **public, read-only demo**
+using free Azure tiers. The app code is already demo-ready — it just needs the Azure
+resources and a few config values.
+
+What "demo mode" does (all controlled by `DemoMode:Enabled=true`):
+- **Read-only** — every mutating action is blocked server-side (you can browse, search,
+  and download; you can't create/edit/delete).
+- **Registration disabled** — the sign-in page shows the two demo logins instead.
+- **AI disabled** — no provider key needed in the cloud; documents show pre-seeded summaries.
+- **Seeded data** — on first request the DB is migrated and filled with demo content
+  (documents, teams, projects, folders, and ~90 days of usage data for the admin charts).
+
+Demo logins (shown on the sign-in page):
+- User: `demo@docflowhub.com` / `Demo123!`
+- Admin: `demo-admin@docflowhub.com` / `Demo123!`
+
+---
+
+## 1. Create the Azure resources (free tiers)
+
+You can do this in the Azure Portal or with the `az` CLI. Names must be globally unique
+where noted.
+
+1. **Resource group** — e.g. `docflowhub-demo-rg` (pick a region close to you).
+2. **Azure SQL Database** — create a SQL *server* + a database on the **free/serverless**
+   tier. Note the server admin login/password. Allow Azure services to access the server
+   (firewall rule "Allow Azure services").
+3. **Storage account** — Standard LRS. Create a **blob container** named `documents`.
+   Copy the storage **connection string** (Access keys blade).
+4. **App Service** — create a **Linux** Web App on a **Free (F1)** App Service Plan,
+   runtime **.NET 9 (STS)**. This name is your `AZURE_WEBAPP_NAME`.
+
+## 2. Configure the Web App (Settings → Environment variables / Application settings)
+
+Add these (note the double-underscore `__` — that's how nested config maps to env vars):
+
+| Name | Value |
+|------|-------|
+| `DemoMode__Enabled` | `true` |
+| `ASPNETCORE_ENVIRONMENT` | `Production` |
+| `ConnectionStrings__DefaultConnection` | *your Azure SQL connection string* |
+| `ConnectionStrings__ApplicationDbContextConnection` | *same Azure SQL connection string* |
+| `DocumentStorage__ConnectionString` | *your storage account connection string* |
+| `DocumentStorage__ContainerName` | `documents` |
+
+**Do NOT set any AI key** (`DocFlowHub:AnthropicApiKey`, `OpenAI:ApiKey`) — AI is disabled
+in demo mode and none is needed.
+
+> The SQL connection string should use SQL auth (the server admin login you created), e.g.
+> `Server=tcp:YOURSERVER.database.windows.net,1433;Database=YOURDB;User ID=...;Password=...;Encrypt=True;TrustServerCertificate=False;`
+
+## 3. Wire up GitHub Actions deploy
+
+1. In the Azure Web App → **Get publish profile** (download the `.PublishSettings` file).
+2. In GitHub → repo **Settings → Secrets and variables → Actions → New repository secret**:
+   - Name: `AZURE_WEBAPP_PUBLISH_PROFILE`
+   - Value: paste the entire contents of the downloaded publish-profile file.
+3. Edit `.github/workflows/deploy-demo.yml` → set `AZURE_WEBAPP_NAME` to your App Service name.
+4. GitHub → **Actions → "Deploy demo to Azure" → Run workflow**.
+
+## 4. First run
+
+On the first request after deploy, the app:
+- runs EF Core migrations (creates the schema), then
+- seeds the demo dataset (idempotent — subsequent restarts won't duplicate it).
+
+The first request may take a few seconds (F1 has no Always-On). Then open the site,
+sign in with a demo login above, and browse. Sign in as the **demo admin** to see the
+admin dashboards/charts populated.
+
+## Notes & limits
+
+- **Downloads of seeded documents** won't return a real file — the seed creates document
+  *metadata* (for lists, details, versions, and charts) with placeholder storage paths, not
+  actual blobs. Everything else (browsing, search, details, admin analytics) works. To make
+  downloads work, upload matching blobs to the `documents` container or extend the seeder.
+- **F1 Free** sleeps when idle and has limited CPU/RAM — fine for a demo, not for load.
+- To take the demo down, stop or delete the App Service; to reset data, drop the SQL
+  database and let the next request re-migrate + re-seed.

--- a/src/DocFlowHub.Core/Constants/DemoAccounts.cs
+++ b/src/DocFlowHub.Core/Constants/DemoAccounts.cs
@@ -1,0 +1,20 @@
+namespace DocFlowHub.Core.Constants;
+
+/// <summary>
+/// Well-known credentials for the public read-only demo. These are intentionally
+/// public — they are shown on the sign-in page so visitors can log in. Both
+/// accounts are read-only (enforced by <c>DemoModePageFilter</c>). Referenced by
+/// the demo login banner and the seeder so they can't drift apart.
+/// </summary>
+public static class DemoAccounts
+{
+    public const string Password = "Demo123!";
+
+    public const string UserEmail = "demo@docflowhub.com";
+    public const string UserFirstName = "Demo";
+    public const string UserLastName = "User";
+
+    public const string AdminEmail = "demo-admin@docflowhub.com";
+    public const string AdminFirstName = "Demo";
+    public const string AdminLastName = "Admin";
+}

--- a/src/DocFlowHub.Core/Services/Interfaces/IDemoModeService.cs
+++ b/src/DocFlowHub.Core/Services/Interfaces/IDemoModeService.cs
@@ -1,0 +1,12 @@
+namespace DocFlowHub.Core.Services.Interfaces;
+
+/// <summary>
+/// Exposes whether the app is running as a public, read-only "demo"
+/// (controlled by the <c>DemoMode:Enabled</c> config flag). Used to enforce
+/// read-only behavior, block registration, short-circuit AI generation, and
+/// surface the demo banner. Off by default — has no effect in normal runs.
+/// </summary>
+public interface IDemoModeService
+{
+    bool IsEnabled { get; }
+}

--- a/src/DocFlowHub.Infrastructure/Data/DbInitializer.cs
+++ b/src/DocFlowHub.Infrastructure/Data/DbInitializer.cs
@@ -1,7 +1,9 @@
 using DocFlowHub.Core.Identity;
+using DocFlowHub.Core.Services.Interfaces;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace DocFlowHub.Infrastructure.Data;
 
@@ -22,6 +24,14 @@ public static class DbInitializer
 
         // Seed admin user if none exists
         await SeedAdminUserAsync(userManager);
+
+        // In the public read-only demo, seed a large, time-distributed dataset.
+        var demoMode = scope.ServiceProvider.GetRequiredService<IDemoModeService>();
+        if (demoMode.IsEnabled)
+        {
+            var logger = scope.ServiceProvider.GetRequiredService<ILoggerFactory>().CreateLogger("DemoDataSeeder");
+            await DemoDataSeeder.SeedAsync(context, userManager, logger);
+        }
     }
 
     private static async Task SeedRolesAsync(RoleManager<IdentityRole> roleManager)

--- a/src/DocFlowHub.Infrastructure/Data/DemoDataSeeder.cs
+++ b/src/DocFlowHub.Infrastructure/Data/DemoDataSeeder.cs
@@ -1,0 +1,344 @@
+using DocFlowHub.Core.Constants;
+using DocFlowHub.Core.Identity;
+using DocFlowHub.Core.Models;
+using DocFlowHub.Core.Models.AI;
+using DocFlowHub.Core.Models.Documents;
+using DocFlowHub.Core.Models.Projects;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace DocFlowHub.Infrastructure.Data;
+
+/// <summary>
+/// Seeds a large, realistic, time-distributed dataset for the public read-only demo:
+/// two demo accounts, categories, teams, projects/folders, ~50 documents (with
+/// versions + static AI summaries), and a few hundred AI-usage log rows spread over
+/// time so the admin dashboards/charts look populated. Idempotent — only seeds when
+/// the demo user has no documents yet, so it is safe to run on every startup (F1 has
+/// no Always-On, so the seed runs on the first request).
+/// </summary>
+public static class DemoDataSeeder
+{
+    // Deterministic RNG so repeated fresh seeds produce the same demo.
+    private const int Seed = 20260710;
+
+    public static async Task SeedAsync(
+        ApplicationDbContext context,
+        UserManager<ApplicationUser> userManager,
+        ILogger logger)
+    {
+        var now = DateTime.UtcNow;
+        var rng = new Random(Seed);
+
+        var demoUser = await EnsureUserAsync(userManager, DemoAccounts.UserEmail,
+            DemoAccounts.UserFirstName, DemoAccounts.UserLastName, "User", now.AddDays(-400));
+        var demoAdmin = await EnsureUserAsync(userManager, DemoAccounts.AdminEmail,
+            DemoAccounts.AdminFirstName, DemoAccounts.AdminLastName, "Administrator", now.AddDays(-420));
+
+        // Idempotency guard: if the demo user already owns documents, assume seeded.
+        if (await context.Documents.AnyAsync(d => d.OwnerId == demoUser.Id))
+        {
+            logger.LogInformation("Demo data already present — skipping demo seed.");
+            return;
+        }
+
+        logger.LogInformation("Seeding demo data...");
+
+        var owners = new[] { demoUser.Id, demoAdmin.Id };
+
+        // ---- Categories ------------------------------------------------------
+        var categoryNames = new[] { "Reports", "Contracts", "Invoices", "Specifications", "Manuals", "Presentations", "Policies" };
+        var categories = new List<DocumentCategory>();
+        foreach (var name in categoryNames)
+        {
+            var existing = await context.DocumentCategories.FirstOrDefaultAsync(c => c.Name == name);
+            if (existing == null)
+            {
+                existing = new DocumentCategory { Name = name, Description = $"{name} documents", CreatedAt = now.AddDays(-390), IsActive = true };
+                context.DocumentCategories.Add(existing);
+            }
+            categories.Add(existing);
+        }
+        await context.SaveChangesAsync();
+
+        // ---- Teams + members -------------------------------------------------
+        var teamNames = new[] { "Engineering", "Marketing", "Operations", "Finance" };
+        var teams = new List<Team>();
+        foreach (var name in teamNames)
+        {
+            var existing = await context.Teams.FirstOrDefaultAsync(t => t.Name == name);
+            if (existing == null)
+            {
+                existing = new Team
+                {
+                    Name = name,
+                    Description = $"{name} team workspace",
+                    OwnerId = demoAdmin.Id,
+                    CreatedAt = now.AddDays(-rng.Next(300, 380)),
+                    Members = new List<TeamMember>
+                    {
+                        new() { UserId = demoAdmin.Id, Role = TeamRole.Admin, JoinedAt = now.AddDays(-360) },
+                        new() { UserId = demoUser.Id, Role = TeamRole.Member, JoinedAt = now.AddDays(-350) },
+                    }
+                };
+                context.Teams.Add(existing);
+            }
+            teams.Add(existing);
+        }
+        await context.SaveChangesAsync();
+
+        // ---- Projects + folders ---------------------------------------------
+        var projectSpecs = new (string Name, string Color, string Icon)[]
+        {
+            ("Website Redesign", "#0284c7", "bi-globe"),
+            ("Q3 Financials", "#059669", "bi-graph-up"),
+            ("Product Launch", "#7c3aed", "bi-rocket"),
+            ("Internal Tools", "#d97706", "bi-tools"),
+        };
+        var projects = new List<Project>();
+        var folders = new List<Folder>();
+        foreach (var (name, color, icon) in projectSpecs)
+        {
+            var existing = await context.Projects.FirstOrDefaultAsync(p => p.Name == name);
+            if (existing == null)
+            {
+                existing = new Project
+                {
+                    Name = name,
+                    Description = $"{name} project workspace",
+                    Color = color,
+                    Icon = icon,
+                    IsActive = true,
+                    OwnerId = owners[rng.Next(owners.Length)],
+                    CreatedAt = now.AddDays(-rng.Next(200, 340)),
+                };
+                context.Projects.Add(existing);
+            }
+            projects.Add(existing);
+        }
+        await context.SaveChangesAsync();
+
+        foreach (var project in projects)
+        {
+            if (await context.Folders.AnyAsync(f => f.ProjectId == project.Id))
+            {
+                folders.AddRange(await context.Folders.Where(f => f.ProjectId == project.Id).ToListAsync());
+                continue;
+            }
+
+            var rootNames = new[] { "Drafts", "Final", "Archive" };
+            foreach (var rootName in rootNames)
+            {
+                var root = new Folder
+                {
+                    Name = rootName,
+                    Description = $"{rootName} in {project.Name}",
+                    ProjectId = project.Id,
+                    Level = 0,
+                    Path = $"/{project.Name}/{rootName}",
+                    CreatedByUserId = project.OwnerId,
+                    CreatedAt = project.CreatedAt.AddDays(rng.Next(1, 20)),
+                };
+                context.Folders.Add(root);
+                await context.SaveChangesAsync(); // need root.Id for child path/parent
+
+                // one nested subfolder under "Final"
+                if (rootName == "Final")
+                {
+                    var child = new Folder
+                    {
+                        Name = "Approved",
+                        Description = "Approved documents",
+                        ProjectId = project.Id,
+                        ParentFolderId = root.Id,
+                        Level = 1,
+                        Path = $"{root.Path}/Approved",
+                        CreatedByUserId = project.OwnerId,
+                        CreatedAt = root.CreatedAt.AddDays(rng.Next(1, 15)),
+                    };
+                    context.Folders.Add(child);
+                    folders.Add(child);
+                }
+                folders.Add(root);
+            }
+        }
+        await context.SaveChangesAsync();
+
+        // ---- Documents + versions + summaries -------------------------------
+        var titleNouns = new[] { "Annual Report", "Service Agreement", "Budget Plan", "API Specification", "User Manual", "Roadmap", "Meeting Notes", "Release Notes", "Design Brief", "Security Review", "Onboarding Guide", "Invoice", "Proposal", "Retrospective", "Style Guide" };
+        var fileTypes = new[] { "pdf", "docx", "txt", "xlsx", "md" };
+        var summaryTemplates = new[]
+        {
+            "This document outlines the key objectives, scope, and deliverables. It summarizes the main findings and provides actionable recommendations for the team.",
+            "A concise overview covering background, current status, and next steps. Highlights risks, dependencies, and the proposed timeline for completion.",
+            "Details the requirements and acceptance criteria, along with supporting data. Concludes with a prioritized list of follow-up actions.",
+            "Captures the decisions made, rationale behind them, and assigned owners. Includes open questions to be resolved in the next review.",
+        };
+        var keyPointsTemplates = new[]
+        {
+            "• Clear objectives defined\n• Timeline on track\n• Two open risks identified",
+            "• Budget within target\n• Stakeholders aligned\n• Next review scheduled",
+            "• Requirements finalized\n• Dependencies mapped\n• Owners assigned",
+        };
+
+        var documents = new List<Document>();
+        const int documentCount = 52;
+        for (var i = 0; i < documentCount; i++)
+        {
+            var createdAt = now.AddDays(-rng.Next(1, 360)).AddHours(-rng.Next(0, 24));
+            var ownerId = owners[rng.Next(owners.Length)];
+            var fileType = fileTypes[rng.Next(fileTypes.Length)];
+            var title = $"{titleNouns[rng.Next(titleNouns.Length)]} {2024 + rng.Next(0, 2)}-{rng.Next(1, 13):D2}";
+
+            // ~60% land in a project, ~half of those in a folder; ~35% shared with a team.
+            Project? project = rng.NextDouble() < 0.6 ? projects[rng.Next(projects.Count)] : null;
+            Folder? folder = project != null && rng.NextDouble() < 0.5
+                ? folders.Where(f => f.ProjectId == project.Id).OrderBy(_ => rng.Next()).FirstOrDefault()
+                : null;
+            Team? team = rng.NextDouble() < 0.35 ? teams[rng.Next(teams.Count)] : null;
+
+            var doc = new Document
+            {
+                Title = title,
+                Description = $"Demo {fileType.ToUpper()} document — {title}.",
+                FileType = fileType,
+                FileSize = rng.Next(24_000, 5_000_000),
+                FilePath = string.Empty, // set after Id is known
+                OwnerId = ownerId,
+                TeamId = team?.Id,
+                ProjectId = project?.Id,
+                FolderId = folder?.Id,
+                CreatedAt = createdAt,
+                UpdatedAt = createdAt,
+                IsDeleted = false,
+            };
+
+            // 1–3 versions, dates increasing from the document's creation.
+            var versionCount = rng.Next(1, 4);
+            var versionDate = createdAt;
+            for (var v = 1; v <= versionCount; v++)
+            {
+                doc.Versions.Add(new DocumentVersion
+                {
+                    VersionNumber = v,
+                    FileType = fileType,
+                    FileSize = doc.FileSize + rng.Next(-5000, 20000),
+                    FilePath = string.Empty,
+                    StoragePath = string.Empty,
+                    CreatedAt = versionDate,
+                    UserId = ownerId,
+                    UserName = ownerId == demoUser.Id ? "Demo User" : "Demo Admin",
+                    ChangeSummary = v == 1 ? "Initial version" : $"Revision {v}",
+                    CreatedBy = ownerId,
+                    FileHash = Guid.NewGuid().ToString("N"),
+                });
+                versionDate = versionDate.AddDays(rng.Next(3, 40));
+                if (versionDate > now) versionDate = now;
+            }
+
+            // 2 distinct categories each (avoid a duplicate join row).
+            var c1 = rng.Next(categories.Count);
+            var c2 = (c1 + 1 + rng.Next(categories.Count - 1)) % categories.Count;
+            doc.Categories.Add(categories[c1]);
+            doc.Categories.Add(categories[c2]);
+
+            context.Documents.Add(doc);
+            documents.Add(doc);
+        }
+        await context.SaveChangesAsync();
+
+        // Set FilePath + CurrentVersionId now that Ids exist, and seed ~70% summaries.
+        foreach (var doc in documents)
+        {
+            var latest = doc.Versions.OrderByDescending(v => v.VersionNumber).First();
+            foreach (var v in doc.Versions)
+            {
+                v.FilePath = $"demo/{doc.Id}/v{v.VersionNumber}.{doc.FileType}";
+                v.StoragePath = v.FilePath;
+            }
+            doc.FilePath = latest.FilePath;
+            doc.CurrentVersionId = latest.Id;
+
+            if (rng.NextDouble() < 0.7)
+            {
+                context.DocumentSummaries.Add(new DocumentSummary
+                {
+                    DocumentId = doc.Id,
+                    Summary = summaryTemplates[rng.Next(summaryTemplates.Length)],
+                    KeyPoints = keyPointsTemplates[rng.Next(keyPointsTemplates.Length)],
+                    AIModel = "claude-haiku-4-5",
+                    ConfidenceScore = Math.Round(0.75 + rng.NextDouble() * 0.2, 2),
+                    GeneratedAt = doc.CreatedAt.AddHours(rng.Next(1, 48)),
+                });
+            }
+        }
+        await context.SaveChangesAsync();
+
+        // ---- AI usage logs (time-distributed, for admin charts) --------------
+        var operations = new[] { "Summarization", "VersionComparison" };
+        var models = new[] { "claude-haiku-4-5", "claude-sonnet-5", "gpt-4o-mini" };
+        var usageLogs = new List<AIUsageLog>();
+        const int usageLogCount = 320;
+        for (var i = 0; i < usageLogCount; i++)
+        {
+            var createdAt = now.AddDays(-rng.Next(0, 90)).AddMinutes(-rng.Next(0, 1440));
+            var inputTokens = rng.Next(400, 6000);
+            var outputTokens = rng.Next(80, 900);
+            var tokens = inputTokens + outputTokens;
+            usageLogs.Add(new AIUsageLog
+            {
+                UserId = owners[rng.Next(owners.Length)],
+                OperationType = operations[rng.Next(operations.Length)],
+                AIModel = models[rng.Next(models.Length)],
+                TokensUsed = tokens,
+                EstimatedCost = Math.Round((decimal)(inputTokens * 0.000001 + outputTokens * 0.000005), 6),
+                ResponseTime = TimeSpan.FromMilliseconds(rng.Next(350, 4200)),
+                IsSuccess = rng.NextDouble() > 0.05,
+                CreatedAt = createdAt,
+                DocumentId = documents[rng.Next(documents.Count)].Id,
+                InputSize = inputTokens * 4,
+                OutputSize = outputTokens * 4,
+                ServedFromCache = rng.NextDouble() < 0.2,
+                QualitySetting = 0.7,
+            });
+        }
+        context.AIUsageLogs.AddRange(usageLogs);
+        await context.SaveChangesAsync();
+
+        logger.LogInformation("Demo seed complete: {Docs} documents, {Logs} usage logs.", documents.Count, usageLogs.Count);
+    }
+
+    private static async Task<ApplicationUser> EnsureUserAsync(
+        UserManager<ApplicationUser> userManager,
+        string email, string firstName, string lastName, string role, DateTime createdAt)
+    {
+        var user = await userManager.FindByEmailAsync(email);
+        if (user == null)
+        {
+            user = new ApplicationUser
+            {
+                UserName = email,
+                Email = email,
+                FirstName = firstName,
+                LastName = lastName,
+                EmailConfirmed = true,
+                CreatedAt = createdAt,
+                IsActive = true,
+            };
+            var result = await userManager.CreateAsync(user, DemoAccounts.Password);
+            if (!result.Succeeded)
+            {
+                throw new InvalidOperationException(
+                    $"Failed to create demo user {email}: {string.Join("; ", result.Errors.Select(e => e.Description))}");
+            }
+        }
+
+        if (!await userManager.IsInRoleAsync(user, role))
+        {
+            await userManager.AddToRoleAsync(user, role);
+        }
+
+        return user;
+    }
+}

--- a/src/DocFlowHub.Infrastructure/DependencyInjection.cs
+++ b/src/DocFlowHub.Infrastructure/DependencyInjection.cs
@@ -12,6 +12,7 @@ using DocFlowHub.Infrastructure.Services.AI;
 using DocFlowHub.Infrastructure.Services.Projects;
 using DocFlowHub.Infrastructure.Services.Admin;
 using DocFlowHub.Infrastructure.Services.Analytics;
+using DocFlowHub.Infrastructure.Services;
 
 namespace DocFlowHub.Infrastructure;
 
@@ -24,6 +25,9 @@ public static class DependencyInjection
 
         // Add Memory Caching for AI Services Performance
         services.AddMemoryCache();
+
+        // Demo mode (read-only public demo) — flag read once from config.
+        services.AddSingleton<IDemoModeService, DemoModeService>();
 
         // Document Services
         services.AddScoped<IDocumentService, DocumentService>();

--- a/src/DocFlowHub.Infrastructure/Services/AI/AIServiceRouter.cs
+++ b/src/DocFlowHub.Infrastructure/Services/AI/AIServiceRouter.cs
@@ -20,16 +20,26 @@ public class AIServiceRouter : IAIService
     private readonly IServiceProvider _services;
     private readonly IConfiguration _configuration;
     private readonly ILogger<AIServiceRouter> _logger;
+    private readonly IDemoModeService _demoMode;
 
-    public AIServiceRouter(IServiceProvider services, IConfiguration configuration, ILogger<AIServiceRouter> logger)
+    private const string DemoDisabledMessage = "AI is disabled in the read-only demo.";
+
+    public AIServiceRouter(IServiceProvider services, IConfiguration configuration, ILogger<AIServiceRouter> logger, IDemoModeService demoMode)
     {
         _services = services;
         _configuration = configuration;
         _logger = logger;
+        _demoMode = demoMode;
     }
 
     public async Task<bool> TestConnectivityAsync()
     {
+        // No outbound AI calls in demo mode — no provider key required in the cloud.
+        if (_demoMode.IsEnabled)
+        {
+            return false;
+        }
+
         var providers = ConfiguredProviders().ToList();
         if (providers.Count == 0)
         {
@@ -50,6 +60,17 @@ public class AIServiceRouter : IAIService
 
     public async Task<AIServiceHealth> GetHealthAsync()
     {
+        if (_demoMode.IsEnabled)
+        {
+            return new AIServiceHealth
+            {
+                IsHealthy = false,
+                ResponseTime = TimeSpan.Zero,
+                CheckedAt = DateTime.UtcNow,
+                Status = DemoDisabledMessage
+            };
+        }
+
         var providers = ConfiguredProviders().ToList();
         if (providers.Count == 0)
         {
@@ -86,6 +107,11 @@ public class AIServiceRouter : IAIService
 
     public async Task<AIResponse> GenerateCompletionAsync(string prompt, string? model = null)
     {
+        if (_demoMode.IsEnabled)
+        {
+            return Failure(model, DemoDisabledMessage);
+        }
+
         var (service, error, effectiveModel) = ResolveForCompletion(model);
         return service is null
             ? Failure(model, error)
@@ -94,6 +120,11 @@ public class AIServiceRouter : IAIService
 
     public async Task<AIResponse> GenerateCompletionAsync(string prompt, string systemMessage, string? model = null)
     {
+        if (_demoMode.IsEnabled)
+        {
+            return Failure(model, DemoDisabledMessage);
+        }
+
         var (service, error, effectiveModel) = ResolveForCompletion(model);
         return service is null
             ? Failure(model, error)

--- a/src/DocFlowHub.Infrastructure/Services/DemoModeService.cs
+++ b/src/DocFlowHub.Infrastructure/Services/DemoModeService.cs
@@ -1,0 +1,18 @@
+using DocFlowHub.Core.Services.Interfaces;
+using Microsoft.Extensions.Configuration;
+
+namespace DocFlowHub.Infrastructure.Services;
+
+/// <summary>
+/// Reads the <c>DemoMode:Enabled</c> flag once at construction. Registered as a
+/// singleton — the flag is fixed for the lifetime of the process.
+/// </summary>
+public class DemoModeService : IDemoModeService
+{
+    public bool IsEnabled { get; }
+
+    public DemoModeService(IConfiguration configuration)
+    {
+        IsEnabled = configuration.GetValue<bool>("DemoMode:Enabled");
+    }
+}

--- a/src/DocFlowHub.Web/Filters/DemoModePageFilter.cs
+++ b/src/DocFlowHub.Web/Filters/DemoModePageFilter.cs
@@ -1,0 +1,113 @@
+using DocFlowHub.Core.Services.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+
+namespace DocFlowHub.Web.Filters;
+
+/// <summary>
+/// When <c>DemoMode:Enabled</c> is on, blocks every mutating (POST) page handler
+/// except a small allowlist (login/logout, document downloads). This is the
+/// server-side guarantee that the public demo is genuinely read-only — it holds
+/// regardless of which buttons the UI happens to show or hide.
+/// </summary>
+/// <remarks>
+/// A Razor Pages page filter (not middleware) is used deliberately: it runs
+/// before the handler body executes and it can see the selected handler NAME,
+/// so it can allow <c>Download</c> while blocking <c>Delete</c> on the same page
+/// — something middleware (which only sees the HTTP method + path) cannot do.
+/// </remarks>
+public class DemoModePageFilter : IAsyncPageFilter
+{
+    private readonly IDemoModeService _demo;
+
+    // Pages whose POSTs are always allowed (authentication).
+    private static readonly HashSet<string> AllowedPages = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "/Account/Login",
+        "/Account/Logout",
+    };
+
+    // POST handler names allowed on any page (safe, non-mutating actions).
+    private static readonly HashSet<string> AllowedHandlers = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Download", // Documents/Index + Documents/Details file download (POST, read-only)
+    };
+
+    public DemoModePageFilter(IDemoModeService demo) => _demo = demo;
+
+    public Task OnPageHandlerSelectionAsync(PageHandlerSelectedContext context) => Task.CompletedTask;
+
+    public async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+    {
+        if (!_demo.IsEnabled || !HttpMethods.IsPost(context.HttpContext.Request.Method))
+        {
+            await next();
+            return;
+        }
+
+        var pagePath = (context.ActionDescriptor as CompiledPageActionDescriptor)?.ViewEnginePath;
+        var handlerName = context.HandlerMethod?.Name;
+
+        var allowed = (pagePath != null && AllowedPages.Contains(pagePath))
+                      || (handlerName != null && AllowedHandlers.Contains(handlerName));
+
+        if (allowed)
+        {
+            await next();
+            return;
+        }
+
+        // Blocked — the mutating handler never runs.
+        context.Result = BuildBlockedResult(context.HttpContext);
+    }
+
+    private static IActionResult BuildBlockedResult(HttpContext http)
+    {
+        const string message = "This is a read-only demo — changes are disabled.";
+
+        if (IsApiRequest(http))
+        {
+            return new JsonResult(new { success = false, message })
+            {
+                StatusCode = StatusCodes.Status403Forbidden
+            };
+        }
+
+        // Flash a message, then send the user back where they came from (same-origin only).
+        var tempFactory = http.RequestServices.GetService<ITempDataDictionaryFactory>();
+        if (tempFactory != null)
+        {
+            var tempData = tempFactory.GetTempData(http);
+            tempData["DemoReadOnlyMessage"] = message;
+        }
+
+        return new RedirectResult(GetSafeReturnTarget(http));
+    }
+
+    /// <summary>Referer, but only if it points at our own host — otherwise "/". Avoids open redirect.</summary>
+    private static string GetSafeReturnTarget(HttpContext http)
+    {
+        var referer = http.Request.Headers.Referer.ToString();
+        if (!string.IsNullOrWhiteSpace(referer)
+            && Uri.TryCreate(referer, UriKind.Absolute, out var refUri)
+            && string.Equals(refUri.Host, http.Request.Host.Host, StringComparison.OrdinalIgnoreCase))
+        {
+            return refUri.PathAndQuery;
+        }
+
+        return "/";
+    }
+
+    private static bool IsApiRequest(HttpContext http)
+    {
+        if (string.Equals(http.Request.Headers.XRequestedWith, "XMLHttpRequest", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        if ((http.Request.ContentType ?? string.Empty).Contains("application/json", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        return http.Request.Headers.Accept.ToString().Contains("application/json", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/DocFlowHub.Web/Pages/Account/Login.cshtml
+++ b/src/DocFlowHub.Web/Pages/Account/Login.cshtml
@@ -1,5 +1,6 @@
 @page
 @model DocFlowHub.Web.Pages.Account.LoginModel
+@inject DocFlowHub.Core.Services.Interfaces.IDemoModeService DemoMode
 
 @{
     ViewData["Title"] = "Sign In - DocFlowHub";
@@ -340,6 +341,46 @@
             transform: scale(1.1);
         }
 
+        /* Demo login banner */
+        .demo-login-banner {
+            background: var(--ai-light);
+            border: 1px solid var(--ai-color);
+            border-radius: var(--radius-lg);
+            padding: var(--spacing-4);
+            margin-bottom: var(--spacing-6);
+            font-size: var(--font-size-sm);
+        }
+
+        .demo-login-banner-title {
+            font-weight: var(--font-weight-semibold);
+            color: var(--text-primary);
+            margin-bottom: var(--spacing-2);
+        }
+
+        .demo-login-banner-title i { color: var(--ai-color); }
+
+        .demo-cred {
+            display: flex;
+            align-items: center;
+            gap: var(--spacing-2);
+            margin-top: var(--spacing-1);
+        }
+
+        .demo-cred span {
+            min-width: 48px;
+            color: var(--text-secondary);
+            font-weight: var(--font-weight-medium);
+        }
+
+        .demo-cred code {
+            background: var(--surface-secondary);
+            border: 1px solid var(--border-color);
+            border-radius: var(--radius-base);
+            padding: 0 var(--spacing-2);
+            color: var(--text-primary);
+            font-size: var(--font-size-xs);
+        }
+
         /* Responsive Design — collapse to form-only on narrow screens */
         @@media (max-width: 900px) {
             .auth-brand { display: none; }
@@ -384,6 +425,15 @@
                 <div class="hero-title">Welcome back</div>
                 <div class="hero-subtitle">Sign in to your account</div>
 
+                @if (DemoMode.IsEnabled)
+                {
+                    <div class="demo-login-banner">
+                        <div class="demo-login-banner-title"><i class="bi bi-eye"></i> Read-only demo — sign in with:</div>
+                        <div class="demo-cred"><span>User</span><code>@DocFlowHub.Core.Constants.DemoAccounts.UserEmail</code><code>@DocFlowHub.Core.Constants.DemoAccounts.Password</code></div>
+                        <div class="demo-cred"><span>Admin</span><code>@DocFlowHub.Core.Constants.DemoAccounts.AdminEmail</code><code>@DocFlowHub.Core.Constants.DemoAccounts.Password</code></div>
+                    </div>
+                }
+
                 <form id="account" method="post">
                 @if (!ViewData.ModelState.IsValid)
                 {
@@ -425,8 +475,11 @@
 
             <div class="modern-links-section">
                 <a id="forgot-password" asp-page="./ForgotPassword" class="modern-link">Forgot your password?</a>
-                <span class="modern-divider">•</span>
-                <a asp-page="./Register" asp-route-returnUrl="@Model.ReturnUrl" class="modern-link">Register as a new user</a>
+                @if (!DemoMode.IsEnabled)
+                {
+                    <span class="modern-divider">•</span>
+                    <a asp-page="./Register" asp-route-returnUrl="@Model.ReturnUrl" class="modern-link">Register as a new user</a>
+                }
             </div>
 
             @if ((Model.ExternalLogins?.Count ?? 0) > 0)

--- a/src/DocFlowHub.Web/Pages/Account/Register.cshtml.cs
+++ b/src/DocFlowHub.Web/Pages/Account/Register.cshtml.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.Extensions.Logging;
 using DocFlowHub.Core.Identity;
+using DocFlowHub.Core.Services.Interfaces;
 
 namespace DocFlowHub.Web.Pages.Account
 {
@@ -21,18 +22,21 @@ namespace DocFlowHub.Web.Pages.Account
         private readonly IUserStore<ApplicationUser> _userStore;
         private readonly IUserEmailStore<ApplicationUser> _emailStore;
         private readonly ILogger<RegisterModel> _logger;
+        private readonly IDemoModeService _demoMode;
 
         public RegisterModel(
             UserManager<ApplicationUser> userManager,
             IUserStore<ApplicationUser> userStore,
             SignInManager<ApplicationUser> signInManager,
-            ILogger<RegisterModel> logger)
+            ILogger<RegisterModel> logger,
+            IDemoModeService demoMode)
         {
             _userManager = userManager;
             _userStore = userStore;
             _emailStore = GetEmailStore();
             _signInManager = signInManager;
             _logger = logger;
+            _demoMode = demoMode;
         }
 
         [BindProperty]
@@ -71,14 +75,27 @@ namespace DocFlowHub.Web.Pages.Account
             public string ConfirmPassword { get; set; }
         }
 
-        public async Task OnGetAsync(string returnUrl = null)
+        public async Task<IActionResult> OnGetAsync(string returnUrl = null)
         {
+            // Registration is disabled in the read-only public demo.
+            if (_demoMode.IsEnabled)
+            {
+                return RedirectToPage("/Account/Login");
+            }
+
             ReturnUrl = returnUrl;
             ExternalLogins = (await _signInManager.GetExternalAuthenticationSchemesAsync()).ToList();
+            return Page();
         }
 
         public async Task<IActionResult> OnPostAsync(string returnUrl = null)
         {
+            // Defense in depth — the DemoModePageFilter also blocks this POST.
+            if (_demoMode.IsEnabled)
+            {
+                return RedirectToPage("/Account/Login");
+            }
+
             returnUrl ??= Url.Content("~/");
             ExternalLogins = (await _signInManager.GetExternalAuthenticationSchemesAsync()).ToList();
             if (ModelState.IsValid)

--- a/src/DocFlowHub.Web/Pages/Shared/_Layout.cshtml
+++ b/src/DocFlowHub.Web/Pages/Shared/_Layout.cshtml
@@ -343,6 +343,22 @@
             width: 100%;
         }
 
+        /* Demo mode: read-only flash shown when a mutating action is blocked */
+        .demo-readonly-flash {
+            display: flex;
+            align-items: center;
+            gap: 0.6rem;
+            background: var(--ai-light);
+            border: 1px solid var(--ai-color);
+            color: var(--text-primary);
+            padding: 0.75rem 1rem;
+            border-radius: 10px;
+            margin-bottom: 1.25rem;
+            font-size: 0.9rem;
+        }
+
+        .demo-readonly-flash i { color: var(--ai-color); }
+
         /* Responsive */
         @@media (max-width: 1024px) {
             .sidebar {
@@ -597,6 +613,13 @@
          <!-- Content -->
          <main class="content">
              <div class="content-container">
+                 @if (TempData["DemoReadOnlyMessage"] != null)
+                 {
+                     <div class="demo-readonly-flash" role="alert">
+                         <i class="bi bi-lock-fill"></i>
+                         <span>@TempData["DemoReadOnlyMessage"]</span>
+                     </div>
+                 }
                  @RenderBody()
              </div>
          </main>

--- a/src/DocFlowHub.Web/Program.cs
+++ b/src/DocFlowHub.Web/Program.cs
@@ -8,12 +8,18 @@ using DocFlowHub.Core.Services.Interfaces;
 using DocFlowHub.Infrastructure.Services.Profile;
 using DocFlowHub.Infrastructure.Services.Role;
 using DocFlowHub.Infrastructure;
+using DocFlowHub.Web.Filters;
+using Microsoft.AspNetCore.Mvc;
 
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 builder.Services.AddRazorPages();
 builder.Services.AddInfrastructure(builder.Configuration);
+
+// Demo mode: enforce read-only via a global page filter (no-op unless DemoMode:Enabled).
+builder.Services.AddScoped<DemoModePageFilter>();
+builder.Services.Configure<MvcOptions>(options => options.Filters.AddService<DemoModePageFilter>());
 
 // Add Identity
 builder.Services.AddIdentity<ApplicationUser, IdentityRole>(options =>


### PR DESCRIPTION
## Demo mode — read-only public demo

A public, read-only demo for a hosted showcase. **Off by default** (`DemoMode:Enabled`; enabled in Azure via `DemoMode__Enabled=true`). Built in 5 chunks; each builds clean and was verified with the flag on.

| Chunk | What | Commit |
|---|---|---|
| 1 | Read-only guard: global page filter blocks mutating POSTs except an allowlist (login/logout, Download). AJAX→403, form→flash+redirect. | `a7ed11f` |
| 2 | Block registration (Register redirects to Login) + demo-login banner on sign-in. | `75c8edc` |
| 3 | AI disabled at the single chokepoint (`AIServiceRouter`) — no outbound call / key needed. | `b80cca8` |
| 4 | Large idempotent seed: demo + demo-admin accounts, 52 docs (versions, summaries), teams/projects/folders/categories, 320 time-distributed usage logs for the admin charts. | `b55e7b6` |
| 5 | Manual-trigger Azure deploy workflow + free-tier setup checklist (`docs/demo-deployment.md`). | `027d1b8` |

### Verified
- Guard (flag on): login allowed (302); bulk-delete blocked (403, handler never ran); form-delete blocked (302); download allowed (200).
- Register blocked → 302 to Login; sign-in shows both demo credentials; register link hidden.
- AI router short-circuits; app boots (DI resolves).
- Seed (against a throwaway DB): 52 documents + 320 usage logs; demo login works; Documents page renders cards. Real dev DB untouched; test DB dropped.

### Demo logins
- User: `demo@docflowhub.com` / `Demo123!`  ·  Admin: `demo-admin@docflowhub.com` / `Demo123!`

### Notes
- `appsettings.json` is gitignored here; the flag is env-var driven (`DemoMode__Enabled`).
- Seeded-document **downloads** have no real blob (metadata-only seed) — see the deployment doc.

### To go live
Follow `docs/demo-deployment.md`: create the free-tier Azure resources, set the app settings, add the publish-profile secret, set `AZURE_WEBAPP_NAME`, run the workflow.